### PR TITLE
Add OSM data to locations

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -27,6 +27,7 @@
     .sidenav li>a { font-size: initial; font-weight: initial; }
     div.label { border-bottom: 2px solid rgba(0, 0, 0, 0.25); font-weight: 600; }
     ul.panelist-list, ul.guest-list, ul.host-list, ul.location-list, ul.panelist-list, ul.panelist-stats, ul.scorekeeper-list { line-height: 1.75; list-style: none; margin: 0; padding: 0; }
+    #map { width: 50%; height: 100vh; }
     .data-tbd, .data-na, .data-multiple { font-style: italic; }
     .database-id { background-color: #393b40; color: #eceff1; }
     .scorekeeper-emeritus { background-color: #c5cae9; }

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -1,0 +1,17 @@
+if (document.getElementById("map")) {
+	let x = document.getElementById("map").getAttribute("x");
+	let y = document.getElementById("map").getAttribute("y");
+
+	let mapOptions = {
+		center: [x, y],
+		zoom: 100
+	}
+
+	let map = new L.map('map' , mapOptions);
+
+	let layer = new L.TileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png');
+	map.addLayer(layer);
+
+	let marker = new L.Marker([x, y]);
+	marker.addTo(map);
+}

--- a/app/static/js/map.js
+++ b/app/static/js/map.js
@@ -1,9 +1,9 @@
 if (document.getElementById("map")) {
-	let x = document.getElementById("map").getAttribute("x");
-	let y = document.getElementById("map").getAttribute("y");
+	let lat = document.getElementById("map").getAttribute("lat");
+	let lon = document.getElementById("map").getAttribute("lon");
 
 	let mapOptions = {
-		center: [x, y],
+		center: [lat, lon],
 		zoom: 100
 	}
 

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -7,6 +7,8 @@
     {% if ga_property_code %}
     <!-- Global site tag (gtag.js) - Google Analytics -->
     <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga_property_code }}"></script>
+    <script src = "http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+    <link rel = "stylesheet" href = "http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
     <script>
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}

--- a/app/templates/core/init_js.html
+++ b/app/templates/core/init_js.html
@@ -1,3 +1,4 @@
 <!--JavaScript at end of body for optimized loading-->
 <script src="{{ url_for('static', filename='js/materialize.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/init.js') }}"></script>
+<script src="{{ url_for('static', filename='js/map.js') }}"></script>

--- a/app/templates/locations/details.html
+++ b/app/templates/locations/details.html
@@ -59,6 +59,15 @@
         </div>
     </div>
 </div>
+
+{% if location.coordinates %}
+<div class="row">
+    <div class="col s12">
+        <div id="map" x="{{ location.coordinates.x }}" y="{{ location.coordinates.y }}">
+        </div>
+    </div>
+</div>
+{% endif %}
 </div>
 {% endif %}
 {% endfor %}

--- a/app/templates/locations/details.html
+++ b/app/templates/locations/details.html
@@ -63,7 +63,7 @@
 {% if location.coordinates %}
 <div class="row">
     <div class="col s12">
-        <div id="map" x="{{ location.coordinates.x }}" y="{{ location.coordinates.y }}">
+        <div id="map" lat="{{ location.coordinates.latitude }}" lon="{{ location.coordinates.longitude }}">
         </div>
     </div>
 </div>


### PR DESCRIPTION
This would require `coordinates` be added to the database (along with the respective latitude and longitudinal coordinates, you can see the implementation in details.html).

The current implementation works something like this:
1. When a user goes to a location page, #map is loaded with the attributes lat and lon for the latitude and longitude respectively.
2. map.js picks up on that and creates a map using Leaflet.js and OSM data.