### PR TITLE
Fix time_zone setting parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 5.1.3
+
+### Bugfix
+
+- Fix an issue where the `time_zone` configuration value was being assigned to `settings_config` twice, instead of being assigned to both `settings_config` and `database_config`
+
 ## 5.1.2
 
 ### Component Changes

--- a/app/config.py
+++ b/app/config.py
@@ -57,11 +57,11 @@ def load_config(
 
         settings_config["app_time_zone"] = time_zone_object
         settings_config["time_zone"] = time_zone_string
-        settings_config["time_zone"] = time_zone_string
+        database_config["time_zone"] = time_zone_string
     else:
         settings_config["app_time_zone"] = pytz.timezone("UTC")
         settings_config["time_zone"] = "UTC"
-        settings_config["time_zone"] = "UTC"
+        database_config["time_zone"] = "UTC"
 
     return {
         "database": database_config,

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2022 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.1.2"
+APP_VERSION = "5.1.3"


### PR DESCRIPTION
## Bugfix

- Fix an issue where the `time_zone` configuration value was being assigned to `settings_config` twice, instead of being assigned to both `settings_config` and `database_config`