### PR TITLE
Add Mastodon Link to Footer / Update Config Value Get/Set to Support Default Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 5.1.4
+
+### Application Changes
+
+- Update the URL in footer to use HTTPS instead of HTTP
+- Use `dict.get(key, default_value)` in `app/__init__.py` to get/set configuration values in order to avoid application startup errors if configuration keys are not set.
+  - Default value for `time_zone` is `UTC`
+  - Default values for any URL is an empty string
+- Adding `mastodon_url` and `mastodon_user` configuration keys in the `settings` section of the config file.
+- If the `mastodon_url` and `mastodon_user` keys contain a value, insert a link with `rel="me"` attribute for profile link validation.
+
 ## 5.1.3
 
 ### Bugfix

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -47,15 +47,15 @@ def create_app():
     app.jinja_env.globals["rank_map"] = dicts.PANELIST_RANKS
     app.jinja_env.globals["rendered_at"] = utility.generate_date_time_stamp
 
-    app.jinja_env.globals["time_zone"] = app.config["app_settings"]["app_time_zone"]
-    app.jinja_env.globals["ga_property_code"] = app.config["app_settings"][
-        "ga_property_code"
-    ]
-    app.jinja_env.globals["api_url"] = app.config["app_settings"]["api_url"]
-    app.jinja_env.globals["blog_url"] = app.config["app_settings"]["blog_url"]
-    app.jinja_env.globals["graphs_url"] = app.config["app_settings"]["graphs_url"]
-    app.jinja_env.globals["reports_url"] = app.config["app_settings"]["reports_url"]
-    app.jinja_env.globals["site_url"] = app.config["app_settings"]["site_url"]
+    app.jinja_env.globals["time_zone"] = app.config["app_settings"].get("app_time_zone", "UTC")
+    app.jinja_env.globals["ga_property_code"] = app.config["app_settings"].get("ga_property_code", "")
+    app.jinja_env.globals["api_url"] = app.config["app_settings"].get("api_url", "")
+    app.jinja_env.globals["blog_url"] = app.config["app_settings"].get("blog_url", "")
+    app.jinja_env.globals["graphs_url"] = app.config["app_settings"].get("graphs_url", "")
+    app.jinja_env.globals["reports_url"] = app.config["app_settings"].get("reports_url", "")
+    app.jinja_env.globals["site_url"] = app.config["app_settings"].get("site_url", "")
+    app.jinja_env.globals["mastodon_url"] = app.config["app_settings"].get("mastodon_url", "")
+    app.jinja_env.globals["mastodon_user"] = app.config["app_settings"].get("mastodon_user", "")
 
     # Register Jinja template filters
     app.jinja_env.filters["pretty_jsonify"] = utility.pretty_jsonify

--- a/app/templates/core/footer.html
+++ b/app/templates/core/footer.html
@@ -15,7 +15,13 @@
     </div>
     <div class="footer-copyright">
         <div class="container">
-            Copyright &copy; 2007&ndash;{{ current_year(time_zone) }} <a href="http://linhpham.org/">Linh Pham</a>. All rights reserved.
+            Copyright &copy; 2007&ndash;{{ current_year(time_zone) }}
+            {% if mastodon_url and mastodon_user %}
+            <a href="https://linhpham.org/">Linh Pham</a> (<a rel="me" href="{{ mastodon_url }}">{{ mastodon_user }}</a>).
+            {% else %}
+            <a href="https://linhpham.org/">Linh Pham</a>.
+            {% endif %}
+            All rights reserved.
             <span class="right">
                 <span title="Page Rendered at Time">R: {{ rendered_at(time_zone) }}</span> |
                 <span title="Application Version">V: {{ app_version }}</span> |

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2022 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.1.3"
+APP_VERSION = "5.1.4"

--- a/config.json.dist
+++ b/config.json.dist
@@ -20,6 +20,8 @@
         "ga_property_code": null,
         "recent_days_ahead": 1,
         "recent_days_back": 31,
-        "time_zone": "UTC"
+        "time_zone": "UTC",
+        "mastodon_url": "",
+        "mastodon_user": ""
     }
 }


### PR DESCRIPTION
## Application Changes

- Update the URL in footer to use HTTPS instead of HTTP
- Use `dict.get(key, default_value)` in `app/__init__.py` to get/set configuration values in order to avoid application startup errors if configuration keys are not set.
  - Default value for `time_zone` is `UTC`
  - Default values for any URL is an empty string
- Adding `mastodon_url` and `mastodon_user` configuration keys in the `settings` section of the config file.
- If the `mastodon_url` and `mastodon_user` keys contain a value, insert a link with `rel="me"` attribute for profile link validation.