### PR TITLE
Updating Flask and Werkzeug dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 5.2.2
+
+### Component Changes
+
+- Upgrade Flask from 2.2.2 to 2.2.3
+- Upgrade Werkzeug from 2.2.2 to 2.2.3 to fix a security vulnerability
+
 ## 5.2.1
 
 ### Other Changes

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2023 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.2.1"
+APP_VERSION = "5.2.2"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,8 +4,8 @@ pytest==7.2.0
 black==22.10.0
 
 python-dateutil==2.8.2
-Flask==2.2.2
-Werkzeug==2.2.2
+Flask==2.2.3
+Werkzeug==2.2.3
 gunicorn==20.1.0
 Markdown==3.4.1
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dateutil==2.8.2
-Flask==2.2.2
-Werkzeug==2.2.2
+Flask==2.2.3
+Werkzeug==2.2.3
 gunicorn==20.1.0
 Markdown==3.4.1
 


### PR DESCRIPTION
## Component Changes

- Upgrade Flask from 2.2.2 to 2.2.3
- Upgrade Werkzeug from 2.2.2 to 2.2.3 to fix a security vulnerability