### PR TITLE
Bump dependency versions for wwdtm, etc.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ app/static/robots.txt
 # Ignore New Relic Agent config file
 newrelic.ini
 
+# Deprecated files
+pytest.ini.old
+
 # Ignore macOS DS_Store files
 .DS_Store
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,25 @@
 # Changes
 
+## 5.2.4
+
+### Component Changes
+
+- Upgrade wwdtm from 2.0.8 to 2.0.9, which also includes the following changes:
+  - Upgrade MySQL Connector/Python from 8.0.31 to 8.0.33
+  - Upgrade NumPy from 1.23.4 to 1.24.2
+  - Upgrade python-slugify from 6.1.2 to 8.0.1
+  - Upgrade pytz from 2022.6 to 2023.3
+- Upgrade Markdown from 3.4.1 to 3.4.3
+- Removed python-dateutil as an explicit requirement as it is being pulled in by the wwdtm package
+
+### Development Changes
+
+- Move pytest configuration from `pytest.ini` into `pyproject.toml`
+- Upgrade flake8 from 5.0.4 to 6.0.0
+- Upgrade pycodestyle from 2.9.1 to 2.10.0
+- Upgrade pytest from 7.2.0 to 7.3.1
+- Upgrade black from 22.10.0 to 23.3.0
+
 ## 5.2.3
 
 ### Component Changes

--- a/app/config.py
+++ b/app/config.py
@@ -5,7 +5,6 @@
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Configuration Loading and Parsing for Wait Wait Stats Page"""
 import json
-from multiprocessing import pool
 from typing import Any, Dict
 
 from app import utility
@@ -18,7 +17,7 @@ def load_config(
     config_file_path: str = "config.json",
     connection_pool_size: int = 12,
     connection_pool_name: str = "wwdtm_stats",
-    app_time_zone: str = "UTC"
+    app_time_zone: str = "UTC",
 ) -> Dict[str, Dict[str, Any]]:
     with open(config_file_path, "r") as config_file:
         app_config = json.load(config_file)

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2023 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.2.3"
+APP_VERSION = "5.2.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,14 @@
 [tool.black]
-required-version = "22.10.0"
+required-version = "23.3.0"
 target-version = ["py38", "py39", "py310", "py311"]
+
+[tool.pytest.ini_options]
+minversion = "7.0"
+filterwarnings = [
+    "ignore::DeprecationWarning:mysql.*:",
+]
+norecursedirs = [
+    ".git",
+    "venv",
+    "static",
+]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore::DeprecationWarning:mysql.*:
-norecursedirs = .git venv static

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,12 +1,11 @@
-flake8==5.0.4
-pycodestyle==2.9.1
-pytest==7.2.0
-black==22.10.0
+flake8==6.0.0
+pycodestyle==2.10.0
+pytest==7.3.1
+black==23.3.0
 
-python-dateutil==2.8.2
 Flask==2.2.3
 Werkzeug==2.2.3
 gunicorn==20.1.0
-Markdown==3.4.1
+Markdown==3.4.3
 
-wwdtm==2.0.8
+wwdtm==2.0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
-python-dateutil==2.8.2
 Flask==2.2.3
 Werkzeug==2.2.3
 gunicorn==20.1.0
-Markdown==3.4.1
+Markdown==3.4.3
 
-wwdtm==2.0.8
+wwdtm==2.0.9


### PR DESCRIPTION
## Component Changes

- Upgrade wwdtm from 2.0.8 to 2.0.9, which also includes the following changes:
  - Upgrade MySQL Connector/Python from 8.0.31 to 8.0.33
  - Upgrade NumPy from 1.23.4 to 1.24.2
  - Upgrade python-slugify from 6.1.2 to 8.0.1
  - Upgrade pytz from 2022.6 to 2023.3
- Upgrade Markdown from 3.4.1 to 3.4.3
- Removed python-dateutil as an explicit requirement as it is being pulled in by the wwdtm package

## Development Changes

- Move pytest configuration from `pytest.ini` into `pyproject.toml`
- Upgrade flake8 from 5.0.4 to 6.0.0
- Upgrade pycodestyle from 2.9.1 to 2.10.0
- Upgrade pytest from 7.2.0 to 7.3.1
- Upgrade black from 22.10.0 to 23.3.0