### PR TITLE
Add config option to change location sort order and bump dependency versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 5.3.0
+
+### Application Changes
+
+- Add `settings.sort_by_venue` configuration setting that is used to determine whether to sort the locations by venue name or by state and city for the `/locations`. Defaults to `false`, which matches the previous behavior.
+
+### Component Changes
+
+- Upgrade Flask from 2.2.3 to 2.3.2
+- Upgrade wwdtm from 2.0.9 to 2.1.0
+
 ## 5.2.4
 
 ### Component Changes

--- a/app/config.py
+++ b/app/config.py
@@ -59,6 +59,9 @@ def load_config(
     settings_config["time_zone"] = time_zone_string
     database_config["time_zone"] = time_zone_string
 
+    # Read in setting to override locations sorting
+    settings_config["sort_by_venue"] = bool(settings_config.get("sort_by_venue", False))
+
     return {
         "database": database_config,
         "settings": settings_config,

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -41,7 +41,7 @@ def index():
     """View: Locations Index"""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     location = Location(database_connection=database_connection)
-    location_list = location.retrieve_all()
+    location_list = location.retrieve_all(current_app.config["app_settings"]["sort_by_venue"])
     database_connection.close()
 
     if not location_list:

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2023 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.2.4"
+APP_VERSION = "5.3.0"

--- a/config.json.dist
+++ b/config.json.dist
@@ -22,6 +22,7 @@
         "recent_days_back": 31,
         "time_zone": "UTC",
         "mastodon_url": "",
-        "mastodon_user": ""
+        "mastodon_user": "",
+        "sort_by_venue": false
     }
 }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,9 +3,8 @@ pycodestyle==2.10.0
 pytest==7.3.1
 black==23.3.0
 
-Flask==2.2.3
-Werkzeug==2.2.3
+Flask==2.3.2
 gunicorn==20.1.0
 Markdown==3.4.3
 
-wwdtm==2.0.9
+wwdtm==2.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-Flask==2.2.3
-Werkzeug==2.2.3
+Flask==2.3.2
 gunicorn==20.1.0
 Markdown==3.4.3
 
-wwdtm==2.0.9
+wwdtm==2.1.0


### PR DESCRIPTION
## Application Changes

- Add `settings.sort_by_venue` configuration setting that is used to determine whether to sort the locations by venue name or by state and city for the `/locations`. Defaults to `false`, which matches the previous behavior.

## Component Changes

- Upgrade Flask from 2.2.3 to 2.3.2
- Upgrade wwdtm from 2.0.9 to 2.1.0