### PR TITLE
Adding Support for Panelist Decimal Scores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Application Changes
 
 - Add support for displaying panelist decimal scores stored in a new table column in the Wait Wait Stats Database instead of the standard than integer scores. This is handled via version 2.2.0 of the `wwdtm` library and a new `use_decimal_scores` setting in the `config.json` application configuration file. By default, the value will be set to `false` and must be changed to `true` and the appropriate changes deployed to the Wait Wait Stats Database.
+- Increase the number of digits displayed after the decimal point for certain panelist statistics from 4 to 5
 
 ### Component Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@
 ### Development Changes
 
 - Upgrade black from 23.3.0 to 23.7.0
+- Upgrade flake8 from 6.0.0 to 6.1.0
+- Upgrade pycodestyle from 2.10.0 to 2.11.0
+- Upgrade pytest from 7.3.1 to 7.4.0
 
 ## 5.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Application Changes
 
-- Add support for displaying panelist decimal scores stored in a new table column in the Wait Wait Stats Database instead of the standard integer scores. This is handled via version 2.2.0 of the `wwdtm` library and a new `use_decimal_scores` setting in the `config.json` application configuration file. By default, the value will be set to `false` and must be changed to `true` and the appropriate changes deployed to the Wait Wait Stats Database.
+- Add support for displaying panelist decimal scores stored in a new table column in the Wait Wait Stats Database instead of the standard integer scores. This is handled via version 2.2.0 of the `wwdtm` library and a new `use_decimal_scores` setting in the `config.json` application configuration file. By default, the value will be set to `false` and must be changed to `true`, and the appropriate changes have been deployed to the Wait Wait Stats Database.
 - Increase the number of digits displayed after the decimal point for certain panelist statistics from 4 to 5
 
 ### Component Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changes
 
+## 5.4.0
+
+### Application Changes
+
+- Add support for displaying panelist decimal scores stored in a new table column in the Wait Wait Stats Database instead of the standard than integer scores. This is handled via version 2.2.0 of the `wwdtm` library and a new `use_decimal_scores` setting in the `config.json` application configuration file. By default, the value will be set to `false` and must be changed to `true` and the appropriate changes deployed to the Wait Wait Stats Database.
+
+### Component Changes
+
+- Upgrade wwdtm from 2.1.0 to 2.2.0, which also includes:
+  - Upgrade NumPy from 1.23.2 to 1.24.3
+
+### Development Changes
+
+- Upgrade black from 23.3.0 to 23.7.0
+
 ## 5.3.1
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Application Changes
 
-- Add support for displaying panelist decimal scores stored in a new table column in the Wait Wait Stats Database instead of the standard than integer scores. This is handled via version 2.2.0 of the `wwdtm` library and a new `use_decimal_scores` setting in the `config.json` application configuration file. By default, the value will be set to `false` and must be changed to `true` and the appropriate changes deployed to the Wait Wait Stats Database.
+- Add support for displaying panelist decimal scores stored in a new table column in the Wait Wait Stats Database instead of the standard integer scores. This is handled via version 2.2.0 of the `wwdtm` library and a new `use_decimal_scores` setting in the `config.json` application configuration file. By default, the value will be set to `false` and must be changed to `true` and the appropriate changes deployed to the Wait Wait Stats Database.
 - Increase the number of digits displayed after the decimal point for certain panelist statistics from 4 to 5
 
 ### Component Changes

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,9 +60,8 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-dev@wwdt.me. All complaints will be reviewed and investigated promptly and
-fairly.
+reported to the community leaders responsible for enforcement at [dev@wwdt.me](mailto:dev@wwdt.me).
+All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -60,7 +60,9 @@ def create_app():
     app.jinja_env.globals["mastodon_user"] = _config["settings"].get(
         "mastodon_user", ""
     )
-    app.jinja_env.globals["use_decimal_scores"] = _config["settings"]["use_decimal_scores"]
+    app.jinja_env.globals["use_decimal_scores"] = _config["settings"][
+        "use_decimal_scores"
+    ]
 
     # Register Jinja template filters
     app.jinja_env.filters["pretty_jsonify"] = utility.pretty_jsonify

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -60,6 +60,7 @@ def create_app():
     app.jinja_env.globals["mastodon_user"] = _config["settings"].get(
         "mastodon_user", ""
     )
+    app.jinja_env.globals["use_decimal_scores"] = _config["settings"]["use_decimal_scores"]
 
     # Register Jinja template filters
     app.jinja_env.filters["pretty_jsonify"] = utility.pretty_jsonify

--- a/app/config.py
+++ b/app/config.py
@@ -62,6 +62,9 @@ def load_config(
     # Read in setting to override locations sorting
     settings_config["sort_by_venue"] = bool(settings_config.get("sort_by_venue", False))
 
+    # Read in setting on whether to use decimal scores
+    settings_config["use_decimal_scores"] = bool(settings_config.get("use_decimal_scores", False))
+
     return {
         "database": database_config,
         "settings": settings_config,

--- a/app/config.py
+++ b/app/config.py
@@ -63,7 +63,9 @@ def load_config(
     settings_config["sort_by_venue"] = bool(settings_config.get("sort_by_venue", False))
 
     # Read in setting on whether to use decimal scores
-    settings_config["use_decimal_scores"] = bool(settings_config.get("use_decimal_scores", False))
+    settings_config["use_decimal_scores"] = bool(
+        settings_config.get("use_decimal_scores", False)
+    )
 
     return {
         "database": database_config,

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -41,7 +41,9 @@ def index():
     """View: Locations Index"""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     location = Location(database_connection=database_connection)
-    location_list = location.retrieve_all(current_app.config["app_settings"]["sort_by_venue"])
+    location_list = location.retrieve_all(
+        current_app.config["app_settings"]["sort_by_venue"]
+    )
     database_connection.close()
 
     if not location_list:

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -53,7 +53,10 @@ def details(panelist_slug: str):
     """View: Panelists Details"""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     panelist = Panelist(database_connection=database_connection)
-    details = panelist.retrieve_details_by_slug(panelist_slug)
+    details = panelist.retrieve_details_by_slug(
+        panelist_slug,
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
     database_connection.close()
 
     if not details:
@@ -71,7 +74,9 @@ def all():
     """View: Panelist Details for All Panelists"""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     panelist = Panelist(database_connection=database_connection)
-    panelists = panelist.retrieve_all_details()
+    panelists = panelist.retrieve_all_details(
+        use_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"]
+    )
     database_connection.close()
 
     if not panelists:

--- a/app/panelists/templates/panelists/details.html
+++ b/app/panelists/templates/panelists/details.html
@@ -45,9 +45,9 @@
             <ul class="panelist-stats">
                 <li>Minimum / Maximum: {{ "{:f}".format(panelist.statistics.scoring_decimal.minimum.normalize()) }}
                     / {{ "{:f}".format(panelist.statistics.scoring_decimal.maximum.normalize()) }}</li>
-                <li>Mean: {{ "{:.4f}".format(panelist.statistics.scoring_decimal.mean.normalize()) }}</li>
+                <li>Mean: {{ "{:f}".format(panelist.statistics.scoring_decimal.mean.normalize()) }}</li>
                 <li>Median: {{ "{:f}".format(panelist.statistics.scoring_decimal.median.normalize()) }}</li>
-                <li>Standard Deviation: {{ "{:.4f}".format(panelist.statistics.scoring_decimal.standard_deviation.normalize()) }}</li>
+                <li>Standard Deviation: {{ "{:f}".format(panelist.statistics.scoring_decimal.standard_deviation.normalize()) }}</li>
                 <li>Total: {{ "{:f}".format(panelist.statistics.scoring_decimal.total.normalize()) }}</li>
             </ul>
             {% elif panelist.statistics.scoring %}

--- a/app/panelists/templates/panelists/details.html
+++ b/app/panelists/templates/panelists/details.html
@@ -41,7 +41,16 @@
     </div>
     <div class="col s12 l6 panelist-scoring-info">
         <div class="label">Scoring</div>
-            {% if panelist.statistics %}
+            {% if panelist.statistics.scoring_decimal %}
+            <ul class="panelist-stats">
+                <li>Minimum / Maximum: {{ "{:f}".format(panelist.statistics.scoring_decimal.minimum.normalize()) }}
+                    / {{ "{:f}".format(panelist.statistics.scoring_decimal.maximum.normalize()) }}</li>
+                <li>Mean: {{ "{:.4f}".format(panelist.statistics.scoring_decimal.mean.normalize()) }}</li>
+                <li>Median: {{ "{:f}".format(panelist.statistics.scoring_decimal.median.normalize()) }}</li>
+                <li>Standard Deviation: {{ "{:.4f}".format(panelist.statistics.scoring_decimal.standard_deviation.normalize()) }}</li>
+                <li>Total: {{ "{:f}".format(panelist.statistics.scoring_decimal.total.normalize()) }}</li>
+            </ul>
+            {% elif panelist.statistics.scoring %}
             <ul class="panelist-stats">
                 <li>Minimum / Maximum: {{ panelist.statistics.scoring.minimum }}
                     / {{ panelist.statistics.scoring.maximum }}</li>

--- a/app/panelists/templates/panelists/details.html
+++ b/app/panelists/templates/panelists/details.html
@@ -120,7 +120,15 @@
                                         month=show_date.month,
                                         day=show_date.day) }}">
                     {{appearance.date}}</a>
-                    {% if appearance.score != None %}
+                    {% if appearance.score_decimal != None %}
+                        {{ "{:f}".format(appearance.score_decimal.normalize()) }}
+                        {% if appearance.lightning_round_start != None and appearance.lightning_round_correct != None %}
+                            ({{ appearance.lightning_round_start}} / {{ appearance.lightning_round_correct}})
+                        {% endif %}
+                        {% if appearance.rank %}
+                            <span class="panelist-rank">[{{ rank_map[appearance.rank] }}]</span>
+                        {% endif %}
+                    {% elif appearance.score != None %}
                         {{ appearance.score }}
                         {% if appearance.lightning_round_start != None and appearance.lightning_round_correct != None %}
                             ({{ appearance.lightning_round_start}} / {{ appearance.lightning_round_correct}})

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -92,7 +92,12 @@ def year(year: Union[str, int]):
     try:
         year = int(year)
         date_year = date(year=year, month=1, day=1)
-        show_months = show.retrieve_months_by_year(year=year)
+        show_months = show.retrieve_months_by_year(
+            year=year,
+            include_decimal_scores=current_app.config["app_settings"][
+                "use_decimal_scores"
+            ],
+        )
         database_connection.close()
 
         if not show_months:
@@ -119,7 +124,13 @@ def year_month(year: int, month: int):
 
     try:
         year_month = date(year=year, month=month, day=1)
-        shows = show.retrieve_details_by_year_month(year=year, month=month)
+        shows = show.retrieve_details_by_year_month(
+            year=year,
+            month=month,
+            include_decimal_scores=current_app.config["app_settings"][
+                "use_decimal_scores"
+            ],
+        )
         database_connection.close()
 
         if not shows:
@@ -143,7 +154,14 @@ def year_month_day(year: int, month: int, day: int):
 
     try:
         show_date = date(year=year, month=month, day=day)
-        details = show.retrieve_details_by_date(year=year, month=month, day=day)
+        details = show.retrieve_details_by_date(
+            year=year,
+            month=month,
+            day=day,
+            include_decimal_scores=current_app.config["app_settings"][
+                "use_decimal_scores"
+            ],
+        )
         database_connection.close()
 
         if not details:
@@ -170,7 +188,12 @@ def year_all(year: int):
 
     try:
         _ = date(year=year, month=1, day=1)
-        shows = show.retrieve_details_by_year(year=year)
+        shows = show.retrieve_details_by_year(
+            year=year,
+            include_decimal_scores=current_app.config["app_settings"][
+                "use_decimal_scores"
+            ],
+        )
         database_connection.close()
 
         if not shows:
@@ -200,7 +223,12 @@ def all():
 
         shows_by_year = {}
         for year in show_years:
-            shows = show.retrieve_details_by_year(year=year)
+            shows = show.retrieve_details_by_year(
+                year=year,
+                include_decimal_scores=current_app.config["app_settings"][
+                    "use_decimal_scores"
+                ],
+            )
             shows_by_year[year] = shows
 
         database_connection.close()
@@ -221,7 +249,11 @@ def on_this_day():
     database_connection = mysql.connector.connect(**current_app.config["database"])
     show = Show(database_connection=database_connection)
     today = date.today()
-    shows = show.retrieve_details_by_month_day(month=today.month, day=today.day)
+    shows = show.retrieve_details_by_month_day(
+        month=today.month,
+        day=today.day,
+        include_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"],
+    )
     database_connection.close()
 
     if not shows:

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -92,12 +92,7 @@ def year(year: Union[str, int]):
     try:
         year = int(year)
         date_year = date(year=year, month=1, day=1)
-        show_months = show.retrieve_months_by_year(
-            year=year,
-            include_decimal_scores=current_app.config["app_settings"][
-                "use_decimal_scores"
-            ],
-        )
+        show_months = show.retrieve_months_by_year(year=year)
         database_connection.close()
 
         if not show_months:

--- a/app/shows/templates/shows/all_details.html
+++ b/app/shows/templates/shows/all_details.html
@@ -79,7 +79,13 @@
             {% for panelist in show.panelists %}
                 <li>
                     {{ "%s:"|format(rank_map[panelist.rank]) if panelist.rank }}
-                    {% if panelist.score %}
+                    {% if use_decimal_scores and panelist.score_decimal %}
+                        <a href="{{ url_for('panelists.details',
+                                            panelist_slug=panelist.slug) }}">{{ panelist.name }}</a> {{ "{:f}".format(panelist.score_decimal.normalize()) }}
+                        {% if panelist.lightning_round_start != None and panelist.lightning_round_correct != None %}
+                            ({{ panelist.lightning_round_start}} / {{ panelist.lightning_round_correct}})
+                        {% endif %}
+                    {% elif panelist.score %}
                         <a href="{{ url_for('panelists.details',
                                             panelist_slug=panelist.slug) }}">{{ panelist.name }}</a> {{ panelist.score }}
                         {% if panelist.lightning_round_start != None and panelist.lightning_round_correct != None %}

--- a/app/shows/templates/shows/details.html
+++ b/app/shows/templates/shows/details.html
@@ -76,7 +76,13 @@
             {% for panelist in show.panelists %}
                 <li>
                     {{ "%s:"|format(rank_map[panelist.rank]) if panelist.rank }}
-                    {% if panelist.score %}
+                    {% if use_decimal_scores and panelist.score_decimal %}
+                        <a href="{{ url_for('panelists.details',
+                                            panelist_slug=panelist.slug) }}">{{ panelist.name }}</a> {{ "{:f}".format(panelist.score_decimal.normalize()) }}
+                        {% if panelist.lightning_round_start != None and panelist.lightning_round_correct != None %}
+                            ({{ panelist.lightning_round_start}} / {{ panelist.lightning_round_correct}})
+                        {% endif %}
+                    {% elif panelist.score %}
                         <a href="{{ url_for('panelists.details',
                                             panelist_slug=panelist.slug) }}">{{ panelist.name }}</a> {{ panelist.score }}
                         {% if panelist.lightning_round_start != None and panelist.lightning_round_correct != None %}

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2023 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.3.1"
+APP_VERSION = "5.4.0"

--- a/config.json.dist
+++ b/config.json.dist
@@ -23,6 +23,7 @@
         "time_zone": "UTC",
         "mastodon_url": "",
         "mastodon_user": "",
-        "sort_by_venue": false
+        "sort_by_venue": false,
+        "use_decimal_scores": true
     }
 }

--- a/config.json.dist
+++ b/config.json.dist
@@ -24,6 +24,6 @@
         "mastodon_url": "",
         "mastodon_user": "",
         "sort_by_venue": false,
-        "use_decimal_scores": true
+        "use_decimal_scores": false
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-required-version = "23.3.0"
+required-version = "23.7.0"
 target-version = ["py38", "py39", "py310", "py311"]
 
 [tool.pytest.ini_options]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
-flake8==6.0.0
-pycodestyle==2.10.0
-pytest==7.3.1
+flake8==6.1.0
+pycodestyle==2.11.0
+pytest==7.4.0
 black==23.7.0
 
 Flask==2.3.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 flake8==6.0.0
 pycodestyle==2.10.0
 pytest==7.3.1
-black==23.3.0
+black==23.7.0
 
 Flask==2.3.2
 gunicorn==20.1.0
 Markdown==3.4.3
 
-wwdtm==2.1.0
+wwdtm==2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==2.3.2
 gunicorn==20.1.0
 Markdown==3.4.3
 
-wwdtm==2.1.0
+wwdtm==2.2.0


### PR DESCRIPTION
## Application Changes

- Add support for displaying panelist decimal scores stored in a new table column in the Wait Wait Stats Database instead of the standard integer scores. This is handled via version 2.2.0 of the `wwdtm` library and a new `use_decimal_scores` setting in the `config.json` application configuration file. By default, the value will be set to `false` and must be changed to `true`, and the appropriate changes have been deployed to the Wait Wait Stats Database.
- Increase the number of digits displayed after the decimal point for certain panelist statistics from 4 to 5

## Component Changes

- Upgrade wwdtm from 2.1.0 to 2.2.0, which also includes:
  - Upgrade NumPy from 1.23.2 to 1.24.3

## Development Changes

- Upgrade black from 23.3.0 to 23.7.0