### PR TITLE
Add support for new panelist Lightning round start and correct decimal columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changes
 
+## 5.5.0
+
+### Application Changes
+
+- Add support for displaying panelist Lightning Fill-in-the-Blank starting score and correct answers stored in the corresponding new table columns. This is handled via version 2.3.0 of the `wwdtm` library and depends on setting the `use_decimal_scores` setting in the `config.json` application configuration file.
+
+### Component Changes
+
+- Upgrade wwdtm from 2.2.0 to 2.3.0
+
 ## 5.4.0
 
 ### Application Changes

--- a/app/panelists/templates/panelists/details.html
+++ b/app/panelists/templates/panelists/details.html
@@ -132,7 +132,8 @@
                     {% if appearance.score_decimal != None %}
                         {{ "{:f}".format(appearance.score_decimal.normalize()) }}
                         {% if appearance.lightning_round_start != None and appearance.lightning_round_correct != None %}
-                            ({{ appearance.lightning_round_start}} / {{ appearance.lightning_round_correct}})
+                            ({{ "{:f}".format(appearance.lightning_round_start_decimal.normalize()) if appearance.lightning_round_start_decimal else appearance.lightning_round_start }}
+                            / {{ "{:f}".format(appearance.lightning_round_correct_decimal.normalize()) if appearance.lightning_round_correct_decimal else appearance.lightning_round_correct }})
                         {% endif %}
                         {% if appearance.rank %}
                             <span class="panelist-rank">[{{ rank_map[appearance.rank] }}]</span>

--- a/app/shows/templates/shows/all_details.html
+++ b/app/shows/templates/shows/all_details.html
@@ -83,7 +83,8 @@
                         <a href="{{ url_for('panelists.details',
                                             panelist_slug=panelist.slug) }}">{{ panelist.name }}</a> {{ "{:f}".format(panelist.score_decimal.normalize()) }}
                         {% if panelist.lightning_round_start != None and panelist.lightning_round_correct != None %}
-                            ({{ panelist.lightning_round_start}} / {{ panelist.lightning_round_correct}})
+                            ({{ "{:f}".format(panelist.lightning_round_start_decimal.normalize()) if panelist.lightning_round_start_decimal else panelist.lightning_round_start }}
+                            / {{ "{:f}".format(panelist.lightning_round_correct_decimal.normalize()) if panelist.lightning_round_correct_decimal else panelist.lightning_round_correct }})
                         {% endif %}
                     {% elif panelist.score %}
                         <a href="{{ url_for('panelists.details',

--- a/app/shows/templates/shows/details.html
+++ b/app/shows/templates/shows/details.html
@@ -80,7 +80,8 @@
                         <a href="{{ url_for('panelists.details',
                                             panelist_slug=panelist.slug) }}">{{ panelist.name }}</a> {{ "{:f}".format(panelist.score_decimal.normalize()) }}
                         {% if panelist.lightning_round_start != None and panelist.lightning_round_correct != None %}
-                            ({{ panelist.lightning_round_start}} / {{ panelist.lightning_round_correct}})
+                            ({{ "{:f}".format(panelist.lightning_round_start_decimal.normalize()) if panelist.lightning_round_start_decimal else panelist.lightning_round_start }}
+                            / {{ "{:f}".format(panelist.lightning_round_correct_decimal.normalize()) if panelist.lightning_round_correct_decimal else panelist.lightning_round_correct }})
                         {% endif %}
                     {% elif panelist.score %}
                         <a href="{{ url_for('panelists.details',

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2023 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.4.0"
+APP_VERSION = "5.5.0"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ Flask==2.3.2
 gunicorn==20.1.0
 Markdown==3.4.3
 
-wwdtm>=2.2.0
+wwdtm==2.3.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ Flask==2.3.2
 gunicorn==20.1.0
 Markdown==3.4.3
 
-wwdtm==2.2.0
+wwdtm>=2.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==2.3.2
 gunicorn==20.1.0
 Markdown==3.4.3
 
-wwdtm==2.2.0
+wwdtm==2.3.0


### PR DESCRIPTION
## Application Changes

- Add support for displaying panelist Lightning Fill-in-the-Blank starting score and correct answers stored in the corresponding new table columns. This is handled via version 2.3.0 of the `wwdtm` library and depends on setting the `use_decimal_scores` setting in the `config.json` application configuration file.

## Component Changes

- Upgrade wwdtm from 2.2.0 to 2.3.0