### PR TITLE
Support Python 3.12, Drop Python < 3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changes
 
+## 5.7.0
+
+**Starting with version 5.7.0, support for all versions of Python prior to 3.10 have been deprecated.**
+
+### Application Changes
+
+- Replace `dateutil.parser.parse` with `datetime.datetime.strptime`
+
+### Component Changes
+
+- Upgrade wwdtm from 2.4.0 to 2.5.0, which drops supports for Python versions prior to 3.10 and includes:
+  - Upgrade MySQL Connector/Python from 8.0.33 to 8.2.0
+  - Upgrade numpy from 1.24.4 to 1.26.0
+
+### Development Changes
+
+- Upgrade black from 23.10.1 to 23.11.0
+- Remove `py38` and `py39` from `tool.black` in `pyproject.toml`
+
 ## 5.6.0
 
 ### Component Changes

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -1,6 +1,6 @@
 # INSTALLING
 
-The following instructions target Ubuntu 20.04 LTS and Ubuntu 22.04 LTS; but, with some minor changes, should also apply to Linux distribution that uses `systemd` to manage services. Python 3.8 or newer is required and the system must already have a working installation available.
+The following instructions target Ubuntu 20.04 LTS and Ubuntu 22.04 LTS; but, with some minor changes, should also apply to Linux distribution that uses `systemd` to manage services. Python 3.10 or newer is required and the system must already have a working installation available.
 
 This document provides instructions on how to serve the application through [Gunicorn](https://gunicorn.org) and use [NGINX](https://nginx.org/) as a front-end HTTP server. Other options are available for serving up applications built using Flask, but those options will not be covered here.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Flask-based web application that serves up statistics and details for the NPR we
 
 ## Requirements
 
-- Python 3.8 or newer
+- Python 3.10 or newer
 - MySQL Server 8.0 or newer, or another MySQL Server distribution based on MySQL Server 8.0 or newer, hosting a version of the aforementioned Wait Wait Don't Tell Me! Stats database
 
 ## Installation

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -5,8 +5,8 @@
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Shows Routes for Wait Wait Stats Page"""
 from datetime import date
+import datetime
 
-from dateutil import parser
 from flask import Blueprint, current_app, render_template, url_for
 import mysql.connector
 from typing import Union
@@ -58,7 +58,7 @@ def index():
 def date_string(date_string: int):
     """View: Show Details for a given ISO Date String"""
     try:
-        parsed_date = parser.parse(date_string)
+        parsed_date = datetime.datetime.strptime(date_string, "%Y-%m-%d")
         database_connection = mysql.connector.connect(**current_app.config["database"])
         show_utility = ShowUtility(database_connection=database_connection)
         if not show_utility.date_exists(
@@ -75,7 +75,7 @@ def date_string(date_string: int):
             ),
             301,
         )
-    except parser.ParserError:
+    except ValueError:
         return redirect_url(url_for("shows.index"))
     except OverflowError:
         return redirect_url(url_for("shows.index"))

--- a/app/utility.py
+++ b/app/utility.py
@@ -7,7 +7,6 @@
 import json
 
 from datetime import datetime
-from dateutil import parser
 from flask import current_app
 import markdown
 import pytz
@@ -23,7 +22,7 @@ def date_string_to_date(**kwargs):
     """Used to convert an ISO-style date string into a datetime object"""
     if "date_string" in kwargs and kwargs["date_string"]:
         try:
-            date_object = parser.parse(kwargs["date_string"])
+            date_object = datetime.strptime(kwargs["date_string"], "%Y-%m-%d")
             return date_object
 
         except ValueError:

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2023 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.6.0"
+APP_VERSION = "5.7.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
-required-version = "23.10.1"
-target-version = ["py38", "py39", "py310", "py311", "py312"]
+required-version = "23.11.0"
+target-version = ["py310", "py311", "py312"]
 
 [tool.pytest.ini_options]
 minversion = "7.4"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,10 @@
 flake8==6.1.0
 pycodestyle==2.11.1
 pytest==7.4.3
-black==23.10.1
+black==23.11.0
 
 Flask==3.0.0
 gunicorn==21.2.0
 Markdown==3.4.3
 
-wwdtm==2.4.0
+wwdtm==2.5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==3.0.0
 gunicorn==21.2.0
 Markdown==3.4.3
 
-wwdtm==2.4.0
+wwdtm==2.5.0


### PR DESCRIPTION
## Application Changes

- Replace `dateutil.parser.parse` with `datetime.datetime.strptime`

## Component Changes

- Upgrade wwdtm from 2.4.0 to 2.5.0, which drops supports for Python versions prior to 3.10 and includes:
  - Upgrade MySQL Connector/Python from 8.0.33 to 8.2.0
  - Upgrade numpy from 1.24.4 to 1.26.0

## Development Changes

- Upgrade black from 23.10.1 to 23.11.0
- Remove `py38` and `py39` from `tool.black` in `pyproject.toml`