### PR TITLE
Remove unnecessary slash in empty tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 5.7.1
+
+### Application Changes
+
+- Remove unneeded slash in an empty tag for the Materialize CSS include
+
 ## 5.7.0
 
 **Starting with version 5.7.0, support for all versions of Python prior to 3.10 have been deprecated.**

--- a/app/templates/core/head.html
+++ b/app/templates/core/head.html
@@ -10,7 +10,7 @@
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap" rel="stylesheet">
 
     <!--Import Materialize -->
-    <link type="text/css" rel="stylesheet" href="{{ url_for('static', filename='css/materialize.min.css') }}"  media="screen"/>
+    <link type="text/css" rel="stylesheet" href="{{ url_for('static', filename='css/materialize.min.css') }}"  media="screen">
 
     <!-- Import Custom CSS -->
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 # Copyright (c) 2018-2023 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 """Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.7.0"
+APP_VERSION = "5.7.1"


### PR DESCRIPTION
## Application Changes

- Remove unneeded slash in an empty tag for the Materialize CSS include