### PR TITLE
Code Cleanup, Linting and Adding Return Type Hints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,12 @@
 {
-    "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true,
-    "python.linting.pylintArgs": [
-        "--extension-pkg-whitelist=numpy,mysql,slugify,wwdtm"
-    ],
     "python.testing.pytestEnabled": true,
-    "python.formatting.provider": "black",
+    "[python]": {
+        "diffEditor.ignoreTrimWhitespace": false,
+        "editor.formatOnSave": true,
+        "editor.codeActionsOnSave": {
+            "source.fixAll": "explicit",
+            "source.organizeImports": "explicit",
+        },
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Application Changes
 
-- Add type hints for a majority of the return types for routes and utility methods
-- Replace use of `typing.Optional` and `typing.Union` with the with the conventions documented in PEP-484 and PEP-604.
+- Add type hints for a majority of the return types for routes and utility modules
+- Replace use of `typing.Optional` and `typing.Union` with the with the conventions documented in PEP-484 and PEP-604
+- Change handling of `time_zone` configuration value to prevent use of `pytz.timezone()` in function arguments
 
 ### Component Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changes
 
+## 5.9.0
+
+### Application Changes
+
+- Add type hints for a majority of the return types for routes and utility methods
+- Replace use of `typing.Optional` and `typing.Union` with the with the conventions documented in PEP-484 and PEP-604.
+
+### Component Changes
+
+- Upgrade wwdtm from 2.6.1 to 2.7.0, which includes:
+  - Upgrade numpy from 1.26.0 to 1.26.3
+- Upgrade Markdown from 3.5.1 to 3.5.2
+
+### Development Changes
+
+- Switch to Ruff for code linting and formatting (with the help of Black)
+- Upgrade pytest from 7.4.3 to 7.4.4
+- Upgrade black from 23.11.0 to 23.12.1
+
+### Documentation Changes
+
+- Update the copyright block at the top of each file to remove `coding` line and to include the appropriate SPDX license identifier
+
 ## 5.8.1
 
 ### Component Changes

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -1,6 +1,6 @@
 # INSTALLING
 
-The following instructions target Ubuntu 20.04 LTS and Ubuntu 22.04 LTS; but, with some minor changes, should also apply to Linux distribution that uses `systemd` to manage services. Python 3.10 or newer is required and the system must already have a working installation available.
+The following instructions target Ubuntu 22.04 LTS and Debian 12; but, with some minor changes, should also apply to Linux distribution that uses `systemd` to manage services. Python 3.10 or newer is required and the system must already have a working installation available.
 
 This document provides instructions on how to serve the application through [Gunicorn](https://gunicorn.org) and use [NGINX](https://nginx.org/) as a front-end HTTP server. Other options are available for serving up applications built using Flask, but those options will not be covered here.
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Core Application for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Core Application for Wait Wait Stats Page."""
 from flask import Flask
 from wwdtm import VERSION as WWDTM_VERSION
 
@@ -12,16 +12,16 @@ from app.errors import handlers
 from app.guests.routes import blueprint as guests_bp
 from app.hosts.routes import blueprint as hosts_bp
 from app.locations.routes import blueprint as locations_bp
-from app.main.routes import blueprint as main_bp
 from app.main.redirects import blueprint as redirects_bp
+from app.main.routes import blueprint as main_bp
 from app.panelists.routes import blueprint as panelists_bp
 from app.scorekeepers.routes import blueprint as scorekeepers_bp
-from app.sitemaps.routes import blueprint as sitemaps_bp
 from app.shows.routes import blueprint as shows_bp
+from app.sitemaps.routes import blueprint as sitemaps_bp
 from app.version import APP_VERSION
 
 
-def create_app():
+def create_app() -> Flask:
     app = Flask(__name__)
     app.url_map.strict_slashes = False
 
@@ -47,7 +47,7 @@ def create_app():
     app.jinja_env.globals["rank_map"] = dicts.PANELIST_RANKS
     app.jinja_env.globals["rendered_at"] = utility.generate_date_time_stamp
 
-    app.jinja_env.globals["time_zone"] = _config["settings"]["app_time_zone"]
+    app.jinja_env.globals["time_zone"] = _config["settings"]["time_zone"]
     app.jinja_env.globals["ga_property_code"] = _config["settings"].get(
         "ga_property_code", ""
     )

--- a/app/config.py
+++ b/app/config.py
@@ -1,11 +1,12 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Configuration Loading and Parsing for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Configuration Loading and Parsing for Wait Wait Stats Page."""
 import json
-from typing import Any, Dict
+from pathlib import Path
+from typing import Any
 
 from app import utility
 
@@ -18,8 +19,9 @@ def load_config(
     connection_pool_size: int = 12,
     connection_pool_name: str = "wwdtm_stats",
     app_time_zone: str = "UTC",
-) -> Dict[str, Dict[str, Any]]:
-    with open(config_file_path, "r") as config_file:
+) -> dict[str, dict[str, Any]]:
+    _config_file_path = Path(config_file_path)
+    with _config_file_path.open(mode="r", encoding="utf-8") as config_file:
         app_config = json.load(config_file)
 
     database_config = app_config.get("database", None)

--- a/app/dicts.py
+++ b/app/dicts.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Dictionary objects used by the Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Dictionary objects used by the Wait Wait Stats Page."""
 
-PANELIST_RANKS = {
+PANELIST_RANKS: dict[str, str] = {
     "1": "First",
     "1t": "First Tied",
     "2": "Second",

--- a/app/errors/__init__.py
+++ b/app/errors/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Errors module for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Errors module for Wait Wait Stats Page."""

--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -1,18 +1,20 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Error Handlers Module for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Error Handlers Module for Wait Wait Stats Page."""
+from typing import Literal
+
 from flask import render_template
-from werkzeug.exceptions import HTTPException
 
 
-def not_found(error):
-    """Handle resource not found conditions"""
+def not_found(error) -> tuple[str, Literal[404]]:
+    """Handle resource not found conditions."""
     return render_template("errors/404.html", error_description=error.description), 404
 
 
-def handle_exception(error):
-    """Handle exceptions in a slightly more graceful manner"""
+def handle_exception(error) -> tuple[str, Literal[500]]:
+    """Handle exceptions in a slightly more graceful manner."""
+    _ = error
     return render_template("errors/500.html"), 500

--- a/app/guests/__init__.py
+++ b/app/guests/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Guests Module for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Guests Module for Wait Wait Stats Page."""

--- a/app/guests/routes.py
+++ b/app/guests/routes.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Guests Routes for Wait Wait Stats Page"""
-from flask import Blueprint, current_app, redirect, render_template, url_for
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Guests Routes for Wait Wait Stats Page."""
 import mysql.connector
+from flask import Blueprint, Response, current_app, redirect, render_template, url_for
 from wwdtm.guest import Guest
 
 from app.utility import redirect_url
@@ -13,8 +13,8 @@ from app.utility import redirect_url
 blueprint = Blueprint("guests", __name__, template_folder="templates")
 
 
-def random_guest_slug() -> str:
-    """Return a random guest slug from ww_guests table"""
+def random_guest_slug() -> str | None:
+    """Return a random guest slug from ww_guests table."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     cursor = database_connection.cursor(dictionary=False)
     query = (
@@ -31,12 +31,12 @@ def random_guest_slug() -> str:
     if not result:
         return None
 
-    return result[0]
+    return str(result[0])
 
 
 @blueprint.route("/")
-def index():
-    """View: Guests Index"""
+def index() -> Response | str:
+    """View: Guests Index."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     guest = Guest(database_connection=database_connection)
     guests = guest.retrieve_all()
@@ -49,8 +49,8 @@ def index():
 
 
 @blueprint.route("/<string:guest_slug>")
-def details(guest_slug: str):
-    """View: Guest Details"""
+def details(guest_slug: str) -> Response | str:
+    """View: Guest Details."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     guest = Guest(database_connection=database_connection)
     details = guest.retrieve_details_by_slug(guest_slug)
@@ -67,8 +67,8 @@ def details(guest_slug: str):
 
 
 @blueprint.route("/all")
-def all():
-    """View: Guest Details for All Guests"""
+def all() -> Response | str:
+    """View: Guest Details for All Guests."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     guest = Guest(database_connection=database_connection)
     guests = guest.retrieve_all_details()
@@ -81,7 +81,7 @@ def all():
 
 
 @blueprint.route("/random")
-def random():
-    """View: Random Guest Redirect"""
+def random() -> Response:
+    """View: Random Guest Redirect."""
     _slug = random_guest_slug()
     return redirect_url(url_for("guests.details", guest_slug=_slug))

--- a/app/hosts/__init__.py
+++ b/app/hosts/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Hosts Module for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Hosts Module for Wait Wait Stats Page."""

--- a/app/hosts/routes.py
+++ b/app/hosts/routes.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Hosts Routes for Wait Wait Stats Page"""
-from flask import Blueprint, current_app, redirect, render_template, url_for
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Hosts Routes for Wait Wait Stats Page."""
 import mysql.connector
+from flask import Blueprint, Response, current_app, redirect, render_template, url_for
 from wwdtm.host import Host
 
 from app.utility import redirect_url
@@ -13,8 +13,8 @@ from app.utility import redirect_url
 blueprint = Blueprint("hosts", __name__, template_folder="templates")
 
 
-def random_host_slug() -> str:
-    """Return a random host slug from ww_hosts table"""
+def random_host_slug() -> str | None:
+    """Return a random host slug from ww_hosts table."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     cursor = database_connection.cursor(dictionary=False)
     query = (
@@ -31,12 +31,12 @@ def random_host_slug() -> str:
     if not result:
         return None
 
-    return result[0]
+    return str(result[0])
 
 
 @blueprint.route("/")
-def index():
-    """View: Hosts Index"""
+def index() -> Response | str:
+    """View: Hosts Index."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     host = Host(database_connection=database_connection)
     hosts = host.retrieve_all()
@@ -49,8 +49,8 @@ def index():
 
 
 @blueprint.route("/<string:host_slug>")
-def details(host_slug: str):
-    """View: Host Details"""
+def details(host_slug: str) -> Response | str:
+    """View: Host Details."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     host = Host(database_connection=database_connection)
     details = host.retrieve_details_by_slug(host_slug)
@@ -65,8 +65,8 @@ def details(host_slug: str):
 
 
 @blueprint.route("/all")
-def all():
-    """View: Host Details for All Hosts"""
+def all() -> Response | str:
+    """View: Host Details for All Hosts."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     host = Host(database_connection=database_connection)
     hosts = host.retrieve_all_details()
@@ -79,7 +79,7 @@ def all():
 
 
 @blueprint.route("/random")
-def random():
-    """View: Random Host Redirect"""
+def random() -> Response:
+    """View: Random Host Redirect."""
     _slug = random_host_slug()
     return redirect_url(url_for("hosts.details", host_slug=_slug))

--- a/app/locations/__init__.py
+++ b/app/locations/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Locations Module for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Locations Module for Wait Wait Stats Page."""

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Locations Routes for Wait Wait Stats Page"""
-from flask import Blueprint, current_app, render_template, url_for
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Locations Routes for Wait Wait Stats Page."""
 import mysql.connector
+from flask import Blueprint, Response, current_app, render_template, url_for
 from slugify import slugify
 from wwdtm.location import Location
 
@@ -15,8 +15,8 @@ from app.utility import redirect_url
 blueprint = Blueprint("locations", __name__, template_folder="templates")
 
 
-def random_location_slug() -> str:
-    """Return a random location slug from ww_locations table"""
+def random_location_slug() -> str | None:
+    """Return a random location slug from ww_locations table."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     cursor = database_connection.cursor(dictionary=False)
     query = (
@@ -33,12 +33,12 @@ def random_location_slug() -> str:
     if not result:
         return None
 
-    return result[0]
+    return str(result[0])
 
 
 @blueprint.route("/")
-def index():
-    """View: Locations Index"""
+def index() -> Response | str:
+    """View: Locations Index."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     location = Location(database_connection=database_connection)
     location_list = location.retrieve_all(
@@ -57,8 +57,8 @@ def index():
 
 
 @blueprint.route("/<string:location_slug>")
-def details(location_slug: str):
-    """View: Location Details"""
+def details(location_slug: str) -> Response | str:
+    """View: Location Details."""
     slug = slugify(location_slug)
     if location_slug and location_slug != slug:
         return redirect_url(url_for("locations.details", location_slug=slug))
@@ -88,8 +88,8 @@ def details(location_slug: str):
 
 
 @blueprint.route("/all")
-def all():
-    """View: Location Details for All Locations"""
+def all() -> Response | str:
+    """View: Location Details for All Locations."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     location = Location(database_connection=database_connection)
     locations = location.retrieve_all_details()
@@ -106,7 +106,7 @@ def all():
 
 
 @blueprint.route("/random")
-def random():
-    """View: Random Location Redirect"""
+def random() -> Response:
+    """View: Random Location Redirect."""
     _slug = random_location_slug()
     return redirect_url(url_for("locations.details", location_slug=_slug))

--- a/app/locations/utility.py
+++ b/app/locations/utility.py
@@ -1,17 +1,13 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Location name formatting functions used by the Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Location name formatting functions used by the Stats Page."""
 
-from typing import Dict, Union
 
-
-def format_location_name(location: Dict) -> Union[str, None]:
-    """Returns a string with a combination of venue name, city
-    and state, depending on what information is available"""
-
+def format_location_name(location: dict) -> str | None:
+    """Formats a location's name."""
     if not location:
         return None
 

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Main Modules for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Main Modules for Wait Wait Stats Page."""

--- a/app/main/redirects.py
+++ b/app/main/redirects.py
@@ -1,12 +1,13 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Main Redirect Routes for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Main Redirect Routes for Wait Wait Stats Page."""
 from datetime import datetime
-from flask import Blueprint, current_app, url_for
+
 import mysql.connector
+from flask import Blueprint, Response, current_app, url_for
 from wwdtm.show import ShowUtility
 
 from app.utility import date_string_to_date, redirect_url
@@ -15,75 +16,74 @@ blueprint = Blueprint("main_redirects", __name__)
 
 
 @blueprint.route("/favicon.ico")
-def favicon():
-    """Redirect: /favicon.ico to /static/favicon.ico"""
+def favicon() -> Response:
+    """Redirect: /favicon.ico to /static/favicon.ico."""
     return redirect_url(url_for("static", filename="favicon.ico"))
 
 
 @blueprint.route("/guest")
 @blueprint.route("/guest/")
 @blueprint.route("/guests")
-def guests():
-    """Redirect: /guest and /guests to /guests/"""
+def guests() -> Response:
+    """Redirect: /guest and /guests to /guests/."""
     return redirect_url(url_for("guests.index"))
 
 
 @blueprint.route("/help")
-def help():
-    """Redirect: /help to /"""
+def help() -> Response:
+    """Redirect: /help to /."""
     return redirect_url(url_for("main.index"))
 
 
 @blueprint.route("/host")
 @blueprint.route("/host/")
 @blueprint.route("/hosts")
-def hosts():
-    """Redirect: /host and /hosts to /hosts/"""
+def hosts() -> Response:
+    """Redirect: /host and /hosts to /hosts/."""
     return redirect_url(url_for("hosts.index"))
 
 
 @blueprint.route("/location")
 @blueprint.route("/location/")
 @blueprint.route("/locations")
-def locations():
-    """Redirect: /location and /locations to /locations/"""
+def locations() -> Response:
+    """Redirect: /location and /locations to /locations/."""
     return redirect_url(url_for("locations.index"))
 
 
 @blueprint.route("/panelist")
 @blueprint.route("/panelist/")
 @blueprint.route("/panelists")
-def panelists():
-    """Redirect: /panelist and /panelists to /panelists/"""
+def panelists() -> Response:
+    """Redirect: /panelist and /panelists to /panelists/."""
     return redirect_url(url_for("panelists.index"))
 
 
 @blueprint.route("/scorekeeper")
 @blueprint.route("/scorekeeper/")
 @blueprint.route("/scorekeepers")
-def scorekeepers():
-    """Redirect: /scorekeeper and /scorekeepers to /scorekeepers/"""
+def scorekeepers() -> Response:
+    """Redirect: /scorekeeper and /scorekeepers to /scorekeepers/."""
     return redirect_url(url_for("scorekeepers.index"))
 
 
 @blueprint.route("/search")
-def search():
-    """Redirect: /search to /"""
+def search() -> Response:
+    """Redirect: /search to /."""
     return redirect_url(url_for("main.index"))
 
 
 @blueprint.route("/show")
 @blueprint.route("/show/")
 @blueprint.route("/shows")
-def shows():
-    """Redirect: /show and /shows to /shows/"""
+def shows() -> Response:
+    """Redirect: /show and /shows to /shows/."""
     return redirect_url(url_for("shows.index"))
 
 
 @blueprint.route("/s/<string:show_date>")
-def npr_show_redirect(show_date: str):
-    """Takes an ISO-like date string and redirects to the appropriate
-    show page on NPR's website."""
+def npr_show_redirect(show_date: str) -> Response:
+    """Redirects users to the appropriate show page on NPR.org."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     show_utility = ShowUtility(database_connection=database_connection)
     show_date_object = date_string_to_date(date_string=show_date)

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,12 +1,13 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Main Routes for Wait Wait Stats Page"""
-from os.path import exists, join
-from flask import Blueprint, Response, current_app, render_template, send_file
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Main Routes for Wait Wait Stats Page."""
+from pathlib import Path
+
 import mysql.connector
+from flask import Blueprint, Response, current_app, render_template, send_file
 from wwdtm.show import Show
 
 from app.config import DEFAULT_RECENT_DAYS_AHEAD, DEFAULT_RECENT_DAYS_BACK
@@ -16,8 +17,8 @@ blueprint = Blueprint("main", __name__)
 
 
 @blueprint.route("/")
-def index():
-    """View: Site Index Page"""
+def index() -> str:
+    """View: Site Index Page."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     _settings = current_app.config["app_settings"]
 
@@ -53,24 +54,23 @@ def index():
 
 
 @blueprint.route("/robots.txt")
-def robots_txt():
-    """View: robots.txt File"""
-    if not exists(join(current_app.root_path, "static", "robots.txt")):
+def robots_txt() -> Response:
+    """View: robots.txt File."""
+    robots_txt_path = Path(current_app.root_path) / "static" / "robots.txt"
+    if not robots_txt_path.exists():
         response = render_template("robots.txt")
         return Response(response, mimetype="text/plain")
     else:
-        return send_file(
-            join(current_app.root_path, "static", "robots.txt"), mimetype="text/plain"
-        )
+        return send_file(robots_txt_path, mimetype="text/plain")
 
 
 @blueprint.route("/about")
-def about():
-    """View: About Page"""
+def about() -> str:
+    """View: About Page."""
     return render_template("pages/about.html")
 
 
 @blueprint.route("/site-history")
-def site_history():
-    """View: Site History Page"""
+def site_history() -> str:
+    """View: Site History Page."""
     return render_template("pages/site_history.html")

--- a/app/panelists/__init__.py
+++ b/app/panelists/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Panelists Module for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Panelists Module for Wait Wait Stats Page."""

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Panelists Routes for Wait Wait Stats Page"""
-from flask import Blueprint, current_app, redirect, render_template, url_for
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Panelists Routes for Wait Wait Stats Page."""
 import mysql.connector
+from flask import Blueprint, Response, current_app, redirect, render_template, url_for
 from wwdtm.panelist import Panelist
 
 from app.utility import redirect_url
@@ -13,8 +13,8 @@ from app.utility import redirect_url
 blueprint = Blueprint("panelists", __name__, template_folder="templates")
 
 
-def random_panelist_slug() -> str:
-    """Return a random panelist slug from ww_panelists table"""
+def random_panelist_slug() -> str | None:
+    """Return a random panelist slug from ww_panelists table."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     cursor = database_connection.cursor(dictionary=False)
     query = (
@@ -31,12 +31,12 @@ def random_panelist_slug() -> str:
     if not result:
         return None
 
-    return result[0]
+    return str(result[0])
 
 
 @blueprint.route("/")
-def index():
-    """View: Panelists Index"""
+def index() -> Response | str:
+    """View: Panelists Index."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     panelist = Panelist(database_connection=database_connection)
     panelists = panelist.retrieve_all()
@@ -49,8 +49,8 @@ def index():
 
 
 @blueprint.route("/<string:panelist_slug>")
-def details(panelist_slug: str):
-    """View: Panelists Details"""
+def details(panelist_slug: str) -> Response | str:
+    """View: Panelists Details."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     panelist = Panelist(database_connection=database_connection)
     details = panelist.retrieve_details_by_slug(
@@ -70,8 +70,8 @@ def details(panelist_slug: str):
 
 
 @blueprint.route("/all")
-def all():
-    """View: Panelist Details for All Panelists"""
+def all() -> Response | str:
+    """View: Panelist Details for All Panelists."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     panelist = Panelist(database_connection=database_connection)
     panelists = panelist.retrieve_all_details(
@@ -86,7 +86,7 @@ def all():
 
 
 @blueprint.route("/random")
-def random():
-    """View: Random Panelist Redirect"""
+def random() -> Response:
+    """View: Random Panelist Redirect."""
     _slug = random_panelist_slug()
     return redirect_url(url_for("panelists.details", panelist_slug=_slug))

--- a/app/scorekeepers/__init__.py
+++ b/app/scorekeepers/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Scorekeepers Module for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Scorekeepers Module for Wait Wait Stats Page."""

--- a/app/scorekeepers/routes.py
+++ b/app/scorekeepers/routes.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Scorekeepers Routes for Wait Wait Stats Page"""
-from flask import Blueprint, current_app, redirect, render_template, url_for
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Scorekeepers Routes for Wait Wait Stats Page."""
 import mysql.connector
+from flask import Blueprint, Response, current_app, redirect, render_template, url_for
 from wwdtm.scorekeeper import Scorekeeper
 
 from app.utility import redirect_url
@@ -13,8 +13,8 @@ from app.utility import redirect_url
 blueprint = Blueprint("scorekeepers", __name__, template_folder="templates")
 
 
-def random_scorekeeper_slug() -> str:
-    """Return a random scorekeeper slug from ww_scorekeepers table"""
+def random_scorekeeper_slug() -> str | None:
+    """Return a random scorekeeper slug from ww_scorekeepers table."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     cursor = database_connection.cursor(dictionary=False)
     query = (
@@ -31,12 +31,12 @@ def random_scorekeeper_slug() -> str:
     if not result:
         return None
 
-    return result[0]
+    return str(result[0])
 
 
 @blueprint.route("/")
-def index():
-    """View: Scorekeepers Index"""
+def index() -> Response | str:
+    """View: Scorekeepers Index."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     scorekeeper = Scorekeeper(database_connection=database_connection)
     scorekeepers = scorekeeper.retrieve_all()
@@ -49,8 +49,8 @@ def index():
 
 
 @blueprint.route("/<string:scorekeeper_slug>")
-def details(scorekeeper_slug: str):
-    """View: Scorekeeper Details"""
+def details(scorekeeper_slug: str) -> Response | str:
+    """View: Scorekeeper Details."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     scorekeeper = Scorekeeper(database_connection=database_connection)
     details = scorekeeper.retrieve_details_by_slug(scorekeeper_slug)
@@ -69,8 +69,8 @@ def details(scorekeeper_slug: str):
 
 
 @blueprint.route("/all")
-def all():
-    """View: Scorekeeper Details for All Scorekeepers"""
+def all() -> Response | str:
+    """View: Scorekeeper Details for All Scorekeepers."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     scorekeeper = Scorekeeper(database_connection=database_connection)
     scorekeepers = scorekeeper.retrieve_all_details()
@@ -83,7 +83,7 @@ def all():
 
 
 @blueprint.route("/random")
-def random():
-    """View: Random Scorekeeper Redirect"""
+def random() -> Response:
+    """View: Random Scorekeeper Redirect."""
     _slug = random_scorekeeper_slug()
     return redirect_url(url_for("scorekeepers.details", scorekeeper_slug=_slug))

--- a/app/shows/__init__.py
+++ b/app/shows/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Shows Module for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Shows Module for Wait Wait Stats Page."""

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -1,15 +1,15 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Shows Routes for Wait Wait Stats Page"""
-from datetime import date
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Shows Routes for Wait Wait Stats Page."""
 import datetime
+from datetime import date
+from typing import Any
 
-from flask import Blueprint, current_app, render_template, url_for
 import mysql.connector
-from typing import Union
+from flask import Blueprint, Response, current_app, render_template, url_for
 from wwdtm.show import Show, ShowUtility
 
 from app.locations.utility import format_location_name
@@ -18,9 +18,8 @@ from app.utility import redirect_url
 blueprint = Blueprint("shows", __name__, template_folder="templates")
 
 
-def random_show_date() -> str:
-    """Return a random show date from the ww_shows table in YYYY-MM-DD
-    format"""
+def random_show_date() -> str | None:
+    """Return a random show date from the ww_shows table."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     cursor = database_connection.cursor(dictionary=False)
     query = (
@@ -41,8 +40,8 @@ def random_show_date() -> str:
 
 
 @blueprint.route("/")
-def index():
-    """View: Shows Index"""
+def index() -> Response | str:
+    """View: Shows Index."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     show = Show(database_connection=database_connection)
     years = show.retrieve_years()
@@ -55,8 +54,8 @@ def index():
 
 
 @blueprint.route("/<string:date_string>")
-def date_string(date_string: int):
-    """View: Show Details for a given ISO Date String"""
+def date_string(date_string: int) -> Response:
+    """View: Show Details for a given ISO Date String."""
     try:
         parsed_date = datetime.datetime.strptime(date_string, "%Y-%m-%d")
         database_connection = mysql.connector.connect(**current_app.config["database"])
@@ -84,8 +83,8 @@ def date_string(date_string: int):
 
 
 @blueprint.route("/<int:year>")
-def year(year: Union[str, int]):
-    """View: List of Available Months for Year"""
+def year(year: str | int) -> Response | str:
+    """View: List of Available Months for Year."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     show = Show(database_connection=database_connection)
 
@@ -112,8 +111,8 @@ def year(year: Union[str, int]):
 
 
 @blueprint.route("/<int:year>/<int:month>")
-def year_month(year: int, month: int):
-    """View: Show Details for Year, Month"""
+def year_month(year: int, month: int) -> Response | str:
+    """View: Show Details for Year, Month."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     show = Show(database_connection=database_connection)
 
@@ -142,8 +141,8 @@ def year_month(year: int, month: int):
 
 
 @blueprint.route("/<int:year>/<int:month>/<int:day>")
-def year_month_day(year: int, month: int, day: int):
-    """View: Show Details for a given Year, Month, Day"""
+def year_month_day(year: int, month: int, day: int) -> Response | str:
+    """View: Show Details for a given Year, Month, Day."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     show = Show(database_connection=database_connection)
 
@@ -176,8 +175,8 @@ def year_month_day(year: int, month: int, day: int):
 
 
 @blueprint.route("/<int:year>/all")
-def year_all(year: int):
-    """View: Show Details for Year"""
+def year_all(year: int) -> Response | str | Any:
+    """View: Show Details for Year."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     show = Show(database_connection=database_connection)
 
@@ -205,8 +204,8 @@ def year_all(year: int):
 
 
 @blueprint.route("/all")
-def all():
-    """View: Show Details for All Shows"""
+def all() -> Response | str:
+    """View: Show Details for All Shows."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     show = Show(database_connection=database_connection)
 
@@ -239,8 +238,8 @@ def all():
 
 
 @blueprint.route("/on-this-day")
-def on_this_day():
-    """View: Show Details for Shows Aired On This Day"""
+def on_this_day() -> Response | str:
+    """View: Show Details for Shows Aired On This Day."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     show = Show(database_connection=database_connection)
     today = date.today()
@@ -260,13 +259,13 @@ def on_this_day():
 
 
 @blueprint.route("/random")
-def random():
-    """View: Random Show Redirect"""
+def random() -> Response:
+    """View: Random Show Redirect."""
     _date = random_show_date()
     return redirect_url(url_for("shows.date_string", date_string=_date))
 
 
 @blueprint.route("/recent")
-def recent():
-    """Redirect: /shows/recent to /"""
+def recent() -> Response:
+    """Redirect: /shows/recent to /."""
     return redirect_url(url_for("main.index"))

--- a/app/sitemaps/__init__.py
+++ b/app/sitemaps/__init__.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Sitemap Modules for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Sitemap Modules for Wait Wait Stats Page."""

--- a/app/sitemaps/routes.py
+++ b/app/sitemaps/routes.py
@@ -1,11 +1,11 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Sitemap Routes for Wait Wait Stats Page"""
-from flask import Blueprint, Response, current_app, render_template
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Sitemap Routes for Wait Wait Stats Page."""
 import mysql.connector
+from flask import Blueprint, Response, current_app, render_template
 from wwdtm.guest import Guest
 from wwdtm.host import Host
 from wwdtm.location import Location
@@ -17,97 +17,97 @@ blueprint = Blueprint("sitemaps", __name__)
 
 
 @blueprint.route("/sitemap.xml")
-def primary():
-    """View: Primary Sitemap XML"""
+def primary() -> Response | None:
+    """View: Primary Sitemap XML."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     show = Show(database_connection=database_connection)
     years = show.retrieve_years()
     database_connection.close()
 
     if not years:
-        return ""
+        return None
 
     sitemap = render_template("sitemaps/sitemap.xml", show_years=years)
     return Response(sitemap, mimetype="text/xml")
 
 
 @blueprint.route("/sitemap-guests.xml")
-def guests():
-    """View: Guests Sitemap XML"""
+def guests() -> Response | None:
+    """View: Guests Sitemap XML."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     guest = Guest(database_connection=database_connection)
     guests = guest.retrieve_all()
     database_connection.close()
 
     if not guests:
-        return ""
+        return None
 
     sitemap = render_template("sitemaps/guests.xml", guests=guests)
     return Response(sitemap, mimetype="text/xml")
 
 
 @blueprint.route("/sitemap-hosts.xml")
-def hosts():
-    """View: Hosts Sitemap XML"""
+def hosts() -> Response | None:
+    """View: Hosts Sitemap XML."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     host = Host(database_connection=database_connection)
     hosts = host.retrieve_all()
     database_connection.close()
 
     if not hosts:
-        return ""
+        return None
 
     sitemap = render_template("sitemaps/hosts.xml", hosts=hosts)
     return Response(sitemap, mimetype="text/xml")
 
 
 @blueprint.route("/sitemap-locations.xml")
-def locations():
-    """View: Locations Sitemap XML"""
+def locations() -> Response | None:
+    """View: Locations Sitemap XML."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     location = Location(database_connection=database_connection)
     locations = location.retrieve_all(sort_by_venue=True)
     database_connection.close()
 
     if not locations:
-        return ""
+        return None
 
     sitemap = render_template("sitemaps/locations.xml", locations=locations)
     return Response(sitemap, mimetype="text/xml")
 
 
 @blueprint.route("/sitemap-panelists.xml")
-def panelists():
-    """View: Panelists Sitemap XML"""
+def panelists() -> Response | None:
+    """View: Panelists Sitemap XML."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     panelist = Panelist(database_connection=database_connection)
     panelists = panelist.retrieve_all()
 
     if not panelists:
-        return ""
+        return None
 
     sitemap = render_template("sitemaps/panelists.xml", panelists=panelists)
     return Response(sitemap, mimetype="text/xml")
 
 
 @blueprint.route("/sitemap-scorekeepers.xml")
-def scorekeepers():
-    """View: Scorekeepers Sitemap XML"""
+def scorekeepers() -> Response | None:
+    """View: Scorekeepers Sitemap XML."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     scorekeeper = Scorekeeper(database_connection=database_connection)
     scorekeepers = scorekeeper.retrieve_all()
     database_connection.close()
 
     if not scorekeepers:
-        return ""
+        return None
 
     sitemap = render_template("sitemaps/scorekeepers.xml", scorekeepers=scorekeepers)
     return Response(sitemap, mimetype="text/xml")
 
 
 @blueprint.route("/sitemap-shows.xml")
-def shows():
-    """View: Shows Sitemap XML"""
+def shows() -> Response | None:
+    """View: Shows Sitemap XML."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     show = Show(database_connection=database_connection)
     dates = show.retrieve_all_dates_tuple()
@@ -115,7 +115,7 @@ def shows():
     database_connection.close()
 
     if not dates or not years_months:
-        return ""
+        return None
 
     sitemap = render_template(
         "sitemaps/shows.xml", show_dates=dates, show_years_months=years_months

--- a/app/utility.py
+++ b/app/utility.py
@@ -1,56 +1,56 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Utility functions used by the Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Utility functions used by the Wait Wait Stats Page."""
 import json
-
 from datetime import datetime
-from flask import current_app
+
 import markdown
 import pytz
+from flask import current_app
 
 
-def current_year(time_zone: pytz.timezone = pytz.timezone("UTC")):
-    """Return the current year"""
-    now = datetime.now(time_zone)
+def current_year(time_zone: str = "UTC") -> str:
+    """Return the current year."""
+    _time_zone = pytz.timezone(time_zone)
+    now = datetime.now(_time_zone)
     return now.strftime("%Y")
 
 
-def date_string_to_date(**kwargs):
-    """Used to convert an ISO-style date string into a datetime object"""
+def date_string_to_date(**kwargs) -> datetime | None:
+    """Used to convert an ISO-style date string into a datetime object."""
     if "date_string" in kwargs and kwargs["date_string"]:
         try:
             date_object = datetime.strptime(kwargs["date_string"], "%Y-%m-%d")
-            return date_object
-
         except ValueError:
             return None
+
+        return date_object
 
     return None
 
 
-def generate_date_time_stamp(time_zone: pytz.timezone = pytz.timezone("UTC")):
-    """Generate a current date/timestamp string"""
-    now = datetime.now(time_zone)
+def generate_date_time_stamp(time_zone: str = "UTC") -> str:
+    """Generate a current date/timestamp string."""
+    _time_zone = pytz.timezone(time_zone)
+    now = datetime.now(_time_zone)
     return now.strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
 def md_to_html(text: str):
-    """Converts Markdown text into HTML"""
+    """Converts Markdown text into HTML."""
     return markdown.markdown(text, output_format="html")
 
 
 def pretty_jsonify(data):
-    """Returns a prettier JSON output for an object than Flask's default
-    tojson filter"""
+    """Returns a prettified JSON output of the data."""
     return json.dumps(data, indent=2)
 
 
 def redirect_url(url: str, status_code: int = 302):
-    """Returns a redirect response for a given URL"""
-
+    """Returns a redirect response for a given URL."""
     # Use a custom response class to force set response headers
     # and handle the redirect to prevent browsers from caching redirect
     response = current_app.response_class(
@@ -64,12 +64,12 @@ def redirect_url(url: str, status_code: int = 302):
     return response
 
 
-def time_zone_parser(time_zone: str) -> pytz.timezone:
+def time_zone_parser(time_zone: str) -> tuple:
     """Parses a time zone name into a pytz.timezone object.
 
     Returns pytz.timezone object and string if time_zone is valid.
-    Otherwise, returns UTC if time zone is not a valid tz value."""
-
+    Otherwise, returns UTC if time zone is not a valid tz value.
+    """
     try:
         time_zone_object = pytz.timezone(time_zone)
         time_zone_string = time_zone_object.zone

--- a/app/version.py
+++ b/app/version.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Application Version for Wait Wait Stats Page"""
-APP_VERSION = "5.8.1"
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Application Version for Wait Wait Stats Page."""
+APP_VERSION = "5.9.0"

--- a/conftest.py
+++ b/conftest.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""pytest conftest.py File"""
-
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""pytest conftest.py File."""
 import pytest
 
 from app import create_app

--- a/gunicorn.conf.py.dist
+++ b/gunicorn.conf.py.dist
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Gunicorn Configuration File"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Gunicorn Configuration File."""
 
 # Make a copy of this file and name it `gunicorn.conf.py` in order
 # for it to be picked up by Gunicorn upon startup. Update any of

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.black]
-required-version = "23.11.0"
+required-version = "23.12.1"
 target-version = ["py310", "py311", "py312"]
+line-length = 88
 
 [tool.pytest.ini_options]
 minversion = "7.4"
@@ -10,5 +11,85 @@ filterwarnings = [
 norecursedirs = [
     ".git",
     "venv",
-    "static",
+    "dist",
+    ".eggs",
+    "wwdtm.egg-info",
 ]
+
+[tool.ruff]
+target-version = "py310"
+select = [
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "D",   # pydocstyle
+    "E",   # Error
+    "F",   # pyflakes
+    "I",   # isort
+    "ISC", # flake8-implicit-str-concat
+    "N",   # pep8-naming
+    "PGH", # pygrep-hooks
+    "PTH", # flake8-use-pathlib
+    "Q",   # flake8-quotes
+    "S",   # bandit
+    "SIM", # flake8-simplify
+    "TRY", # tryceratops
+    "UP",  # pyupgrade
+    "W",   # Warning
+    "YTT", # flake8-2020
+]
+
+exclude = [
+    "migrations",
+    "__pycache__",
+    "manage.py",
+    "settings.py",
+    "env",
+    ".env",
+    "venv",
+    ".venv",
+]
+
+ignore = [
+    "B905",   # zip strict=True; remove once python <3.10 support is dropped.
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D200",
+    "D401",
+    "E402",
+    "E501",
+    "F401",
+    "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
+    "S608",
+]
+line-length = 88 # Must agree with Black
+
+[tool.ruff.flake8-bugbear]
+extend-immutable-calls = ["chr", "typer.Argument", "typer.Option"]
+
+[tool.ruff.pydocstyle]
+convention = "pep257"
+
+[tool.ruff.per-file-ignores]
+"tests/*.py" = [
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "S101",   # use of "assert"
+    "S102",   # use of "exec"
+    "S106",   # possible hardcoded password.
+    "PGH001", # use of "eval"
+]
+
+[tool.ruff.pep8-naming]
+staticmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,10 +1,9 @@
-flake8==6.1.0
-pycodestyle==2.11.1
-pytest==7.4.3
-black==23.11.0
+ruff==0.1.13
+black==23.12.1
+pytest==7.4.4
 
 Flask==3.0.0
 gunicorn==21.2.0
-Markdown==3.5.1
+Markdown==3.5.2
 
-wwdtm==2.6.1
+wwdtm==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Flask==3.0.0
 gunicorn==21.2.0
-Markdown==3.5.1
+Markdown==3.5.2
 
-wwdtm==2.6.1
+wwdtm==2.7.0

--- a/stats.py
+++ b/stats.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Application Bootstrap Script for Wait Wait Stats Page"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Application Bootstrap Script for Wait Wait Stats Page."""
 from app import create_app
 
 app = create_app()

--- a/tests/test_guests.py
+++ b/tests/test_guests.py
@@ -1,16 +1,16 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing Guests Module and Blueprint Views"""
-from flask.testing import FlaskClient
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing Guests Module and Blueprint Views."""
 import pytest
+from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 
 
 def test_index(client: FlaskClient) -> None:
-    """Testing guests.index"""
+    """Testing guests.index."""
     response: TestResponse = client.get("/guests/")
     assert response.status_code == 200
     assert b"Guests" in response.data
@@ -19,7 +19,7 @@ def test_index(client: FlaskClient) -> None:
 
 @pytest.mark.parametrize("guest_slug", ["tom-hanks"])
 def test_details(client: FlaskClient, guest_slug: str) -> None:
-    """Testing guests.details"""
+    """Testing guests.details."""
     response: TestResponse = client.get(f"/guests/{guest_slug}")
     assert response.status_code == 200
     assert b"Guest Details" in response.data
@@ -28,7 +28,7 @@ def test_details(client: FlaskClient, guest_slug: str) -> None:
 
 
 def test_all(client: FlaskClient) -> None:
-    """Testing guests.all"""
+    """Testing guests.all."""
     response: TestResponse = client.get("/guests/all")
     assert response.status_code == 200
     assert b"Guest Details" in response.data
@@ -37,7 +37,7 @@ def test_all(client: FlaskClient) -> None:
 
 
 def test_random(client: FlaskClient) -> None:
-    """Testing guests.random"""
+    """Testing guests.random."""
     response: TestResponse = client.get("/guests/random")
     assert response.status_code == 302
     assert response.location

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -1,16 +1,16 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing Hosts Module and Blueprint Views"""
-from flask.testing import FlaskClient
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing Hosts Module and Blueprint Views."""
 import pytest
+from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 
 
 def test_index(client: FlaskClient) -> None:
-    """Testing hosts.index"""
+    """Testing hosts.index."""
     response: TestResponse = client.get("/hosts/")
     assert response.status_code == 200
     assert b"Hosts" in response.data
@@ -19,7 +19,7 @@ def test_index(client: FlaskClient) -> None:
 
 @pytest.mark.parametrize("host_slug", ["faith-salie"])
 def test_details(client: FlaskClient, host_slug: str) -> None:
-    """Testing hosts.details"""
+    """Testing hosts.details."""
     response: TestResponse = client.get(f"/hosts/{host_slug}")
     assert response.status_code == 200
     assert b"Host Details" in response.data
@@ -28,7 +28,7 @@ def test_details(client: FlaskClient, host_slug: str) -> None:
 
 
 def test_all(client: FlaskClient) -> None:
-    """Testing hosts.all"""
+    """Testing hosts.all."""
     response: TestResponse = client.get("/hosts/all")
     assert response.status_code == 200
     assert b"Host Details" in response.data
@@ -37,7 +37,7 @@ def test_all(client: FlaskClient) -> None:
 
 
 def test_random(client: FlaskClient) -> None:
-    """Testing hosts.random"""
+    """Testing hosts.random."""
     response: TestResponse = client.get("/hosts/random")
     assert response.status_code == 302
     assert response.location

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -1,20 +1,18 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing Locations Module and Blueprint Views"""
-from typing import Dict, Union
-
-from flask.testing import FlaskClient
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing Locations Module and Blueprint Views."""
 import pytest
+from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 
 from app.locations.utility import format_location_name
 
 
 def test_index(client: FlaskClient) -> None:
-    """Testing locations.index"""
+    """Testing locations.index."""
     response: TestResponse = client.get("/locations/")
     assert response.status_code == 200
     assert b"Locations" in response.data
@@ -23,7 +21,7 @@ def test_index(client: FlaskClient) -> None:
 
 @pytest.mark.parametrize("location_slug", ["chase-auditorium-chicago-il"])
 def test_details(client: FlaskClient, location_slug: str) -> None:
-    """Testing locations.details"""
+    """Testing locations.details."""
     response: TestResponse = client.get(f"/locations/{location_slug}")
     assert response.status_code == 200
     assert b"Location Details" in response.data
@@ -32,7 +30,7 @@ def test_details(client: FlaskClient, location_slug: str) -> None:
 
 
 def test_all(client: FlaskClient) -> None:
-    """Testing locations.all"""
+    """Testing locations.all."""
     response: TestResponse = client.get("/locations/all")
     assert response.status_code == 200
     assert b"Location Details" in response.data
@@ -41,7 +39,7 @@ def test_all(client: FlaskClient) -> None:
 
 
 def test_random(client: FlaskClient) -> None:
-    """Testing locations.random"""
+    """Testing locations.random."""
     response: TestResponse = client.get("/locations/random")
     assert response.status_code == 302
     assert response.location
@@ -57,7 +55,7 @@ def test_random(client: FlaskClient) -> None:
         }
     ],
 )
-def test_format_location_name(location: Dict[str, str]) -> None:
-    """Testing locations.utility.format_location_name()"""
-    name: Union[str, None] = format_location_name(location)
+def test_format_location_name(location: dict[str, str]) -> None:
+    """Testing locations.utility.format_location_name()."""
+    name: str | None = format_location_name(location)
     assert name

--- a/tests/test_main_redirects.py
+++ b/tests/test_main_redirects.py
@@ -1,23 +1,23 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing Main Redirects Module and Blueprint Views"""
-from flask.testing import FlaskClient
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing Main Redirects Module and Blueprint Views."""
 import pytest
+from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 
 
 def test_favicon(client: FlaskClient) -> None:
-    """Testing main_redirects.favicon"""
+    """Testing main_redirects.favicon."""
     response: TestResponse = client.get("/favicon.ico")
     assert response.status_code == 302
     assert response.location
 
 
 def test_guests(client: FlaskClient) -> None:
-    """Testing main_redirects.guests"""
+    """Testing main_redirects.guests."""
     response: TestResponse = client.get("/guest")
     assert response.status_code == 302
     assert response.location
@@ -32,14 +32,14 @@ def test_guests(client: FlaskClient) -> None:
 
 
 def test_help(client: FlaskClient) -> None:
-    """Testing main_redirects.help"""
+    """Testing main_redirects.help."""
     response: TestResponse = client.get("/help")
     assert response.status_code == 302
     assert response.location
 
 
 def test_hosts(client: FlaskClient) -> None:
-    """Testing main_redirects.hosts"""
+    """Testing main_redirects.hosts."""
     response: TestResponse = client.get("/host")
     assert response.status_code == 302
     assert response.location
@@ -54,7 +54,7 @@ def test_hosts(client: FlaskClient) -> None:
 
 
 def test_locations(client: FlaskClient) -> None:
-    """Testing main_redirects.locations"""
+    """Testing main_redirects.locations."""
     response: TestResponse = client.get("/location")
     assert response.status_code == 302
     assert response.location
@@ -69,7 +69,7 @@ def test_locations(client: FlaskClient) -> None:
 
 
 def test_scorekeepers(client: FlaskClient) -> None:
-    """Testing main_redirects.scorekeepers"""
+    """Testing main_redirects.scorekeepers."""
     response: TestResponse = client.get("/scorekeeper")
     assert response.status_code == 302
     assert response.location
@@ -84,14 +84,14 @@ def test_scorekeepers(client: FlaskClient) -> None:
 
 
 def test_search(client: FlaskClient) -> None:
-    """Testing main_redirects.search"""
+    """Testing main_redirects.search."""
     response: TestResponse = client.get("/search")
     assert response.status_code == 302
     assert response.location
 
 
 def test_shows(client: FlaskClient) -> None:
-    """Testing main_redirects.shows"""
+    """Testing main_redirects.shows."""
     response: TestResponse = client.get("/show")
     assert response.status_code == 302
     assert response.location
@@ -107,7 +107,7 @@ def test_shows(client: FlaskClient) -> None:
 
 @pytest.mark.parametrize("show_date", ["2018-10-27"])
 def test_npr_show_redirect(client: FlaskClient, show_date: str) -> None:
-    """Testing main_redirects.guest"""
+    """Testing main_redirects.guest."""
     response: TestResponse = client.get(f"/s/{show_date}")
     assert response.status_code == 302
     assert response.location

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -1,15 +1,15 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing Main Routes Module and Blueprint Views"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing Main Routes Module and Blueprint Views."""
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 
 
 def test_index(client: FlaskClient) -> None:
-    """Testing main.index"""
+    """Testing main.index."""
     response: TestResponse = client.get("/")
     assert response.status_code == 200
     assert b"Welcome to the Wait Wait" in response.data
@@ -17,7 +17,7 @@ def test_index(client: FlaskClient) -> None:
 
 
 def test_robots_txt(client: FlaskClient) -> None:
-    """Testing main.robots_txt"""
+    """Testing main.robots_txt."""
     response: TestResponse = client.get("/robots.txt")
     assert response.status_code == 200
     assert b"Sitemap:" in response.data
@@ -25,7 +25,7 @@ def test_robots_txt(client: FlaskClient) -> None:
 
 
 def test_about(client: FlaskClient) -> None:
-    """Testing main.about"""
+    """Testing main.about."""
     response: TestResponse = client.get("/about")
     assert response.status_code == 200
     assert b"Overview" in response.data
@@ -33,7 +33,7 @@ def test_about(client: FlaskClient) -> None:
 
 
 def test_site_history(client: FlaskClient) -> None:
-    """Testing main.site_history"""
+    """Testing main.site_history."""
     response: TestResponse = client.get("/site-history")
     assert response.status_code == 200
     assert b"Versions 1 and 2" in response.data

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -1,16 +1,16 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing Panelists Module and Blueprint Views"""
-from flask.testing import FlaskClient
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing Panelists Module and Blueprint Views."""
 import pytest
+from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 
 
 def test_index(client: FlaskClient) -> None:
-    """Testing panelists.index"""
+    """Testing panelists.index."""
     response: TestResponse = client.get("/panelists/")
     assert response.status_code == 200
     assert b"Panelists" in response.data
@@ -19,7 +19,7 @@ def test_index(client: FlaskClient) -> None:
 
 @pytest.mark.parametrize("panelist_slug", ["faith-salie"])
 def test_details(client: FlaskClient, panelist_slug: str) -> None:
-    """Testing panelists.details"""
+    """Testing panelists.details."""
     response: TestResponse = client.get(f"/panelists/{panelist_slug}")
     assert response.status_code == 200
     assert b"Panelist Details" in response.data
@@ -28,7 +28,7 @@ def test_details(client: FlaskClient, panelist_slug: str) -> None:
 
 
 def test_all(client: FlaskClient) -> None:
-    """Testing panelists.all"""
+    """Testing panelists.all."""
     response: TestResponse = client.get("/panelists/all")
     assert response.status_code == 200
     assert b"Panelist Details" in response.data
@@ -37,7 +37,7 @@ def test_all(client: FlaskClient) -> None:
 
 
 def test_random(client: FlaskClient) -> None:
-    """Testing panelists.random"""
+    """Testing panelists.random."""
     response: TestResponse = client.get("/panelists/random")
     assert response.status_code == 302
     assert response.location

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -1,16 +1,16 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing Scorekeepers Module and Blueprint Views"""
-from flask.testing import FlaskClient
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing Scorekeepers Module and Blueprint Views."""
 import pytest
+from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 
 
 def test_index(client: FlaskClient) -> None:
-    """Testing scorekeepers.index"""
+    """Testing scorekeepers.index."""
     response: TestResponse = client.get("/scorekeepers/")
     assert response.status_code == 200
     assert b"Scorekeepers" in response.data
@@ -19,7 +19,7 @@ def test_index(client: FlaskClient) -> None:
 
 @pytest.mark.parametrize("scorekeepers_slug", ["bill-kurtis"])
 def test_details(client: FlaskClient, scorekeepers_slug: str) -> None:
-    """Testing scorekeepers.details"""
+    """Testing scorekeepers.details."""
     response: TestResponse = client.get(f"/scorekeepers/{scorekeepers_slug}")
     assert response.status_code == 200
     assert b"Scorekeeper Details" in response.data
@@ -28,7 +28,7 @@ def test_details(client: FlaskClient, scorekeepers_slug: str) -> None:
 
 
 def test_all(client: FlaskClient) -> None:
-    """Testing scorekeepers.all"""
+    """Testing scorekeepers.all."""
     response: TestResponse = client.get("/scorekeepers/all")
     assert response.status_code == 200
     assert b"Scorekeeper Details" in response.data
@@ -37,7 +37,7 @@ def test_all(client: FlaskClient) -> None:
 
 
 def test_random(client: FlaskClient) -> None:
-    """Testing scorekeepers.random"""
+    """Testing scorekeepers.random."""
     response: TestResponse = client.get("/scorekeepers/random")
     assert response.status_code == 302
     assert response.location

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -1,16 +1,16 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing Shows Module and Blueprint Views"""
-from flask.testing import FlaskClient
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing Shows Module and Blueprint Views."""
 import pytest
+from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 
 
 def test_index(client: FlaskClient) -> None:
-    """Testing shows.index"""
+    """Testing shows.index."""
     response: TestResponse = client.get("/shows/")
     assert response.status_code == 200
     assert b"Shows" in response.data
@@ -19,7 +19,7 @@ def test_index(client: FlaskClient) -> None:
 
 @pytest.mark.parametrize("date_string", ["2018-10-27"])
 def test_date_string(client: FlaskClient, date_string: str) -> None:
-    """Testing shows.date_string"""
+    """Testing shows.date_string."""
     response: TestResponse = client.get(f"/shows/{date_string}")
     assert response.status_code == 301
     assert response.location
@@ -27,7 +27,7 @@ def test_date_string(client: FlaskClient, date_string: str) -> None:
 
 @pytest.mark.parametrize("year", [2018])
 def test_year(client: FlaskClient, year: int) -> None:
-    """Testing shows.year"""
+    """Testing shows.year."""
     response: TestResponse = client.get(f"/shows/{year}")
     assert response.status_code == 200
     assert b"January" in response.data
@@ -36,7 +36,7 @@ def test_year(client: FlaskClient, year: int) -> None:
 
 @pytest.mark.parametrize("year, month", [(2018, 10)])
 def test_year_month(client: FlaskClient, year: int, month: int) -> None:
-    """Testing shows.year_month"""
+    """Testing shows.year_month."""
     response: TestResponse = client.get(f"/shows/{year}/{month}")
     assert response.status_code == 200
     assert b"Show Details" in response.data
@@ -47,7 +47,7 @@ def test_year_month(client: FlaskClient, year: int, month: int) -> None:
 
 @pytest.mark.parametrize("year, month, day", [(2018, 10, 27)])
 def test_year_month_day(client: FlaskClient, year: int, month: int, day: int) -> None:
-    """Testing shows.year_month_day"""
+    """Testing shows.year_month_day."""
     response: TestResponse = client.get(f"/shows/{year}/{month}/{day}")
     assert response.status_code == 200
     assert b"Show Details" in response.data
@@ -58,7 +58,7 @@ def test_year_month_day(client: FlaskClient, year: int, month: int, day: int) ->
 
 @pytest.mark.parametrize("year", [2018])
 def test_year_all(client: FlaskClient, year: int) -> None:
-    """Testing shows.year_all"""
+    """Testing shows.year_all."""
     response: TestResponse = client.get(f"/shows/{year}/all")
     assert response.status_code == 200
     assert b"Show Details" in response.data
@@ -68,7 +68,7 @@ def test_year_all(client: FlaskClient, year: int) -> None:
 
 
 def test_all(client: FlaskClient) -> None:
-    """Testing shows.all"""
+    """Testing shows.all."""
     response: TestResponse = client.get("/shows/all")
     assert response.status_code == 200
     assert b"All Show Details" in response.data
@@ -79,7 +79,7 @@ def test_all(client: FlaskClient) -> None:
 
 
 def test_on_this_day(client: FlaskClient) -> None:
-    """Testing shows.on_this_day"""
+    """Testing shows.on_this_day."""
     response: TestResponse = client.get("/shows/on-this-day")
     assert response.status_code == 200
     assert b"Show Details" in response.data
@@ -90,14 +90,14 @@ def test_on_this_day(client: FlaskClient) -> None:
 
 
 def test_random(client: FlaskClient) -> None:
-    """Testing shows.random"""
+    """Testing shows.random."""
     response: TestResponse = client.get("/shows/random")
     assert response.status_code == 302
     assert response.location
 
 
 def test_recent(client: FlaskClient) -> None:
-    """Testing shows.recent"""
+    """Testing shows.recent."""
     response: TestResponse = client.get("/shows/recent")
     assert response.status_code == 302
     assert response.location

--- a/tests/test_sitemaps.py
+++ b/tests/test_sitemaps.py
@@ -1,15 +1,15 @@
-# -*- coding: utf-8 -*-
-# vim: set noai syntax=python ts=4 sw=4:
-#
-# Copyright (c) 2018-2023 Linh Pham
+# Copyright (c) 2018-2024 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
-"""Testing Sitemaps Module and Blueprint Views"""
+# SPDX-License-Identifier: Apache-2.0
+#
+# vim: set noai syntax=python ts=4 sw=4:
+"""Testing Sitemaps Module and Blueprint Views."""
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 
 
 def test_primary(client: FlaskClient) -> None:
-    """Testing sitemaps.primary"""
+    """Testing sitemaps.primary."""
     response: TestResponse = client.get("/sitemap.xml")
     assert response.status_code == 200
     assert "Content-Type" in response.headers
@@ -19,7 +19,7 @@ def test_primary(client: FlaskClient) -> None:
 
 
 def test_guest(client: FlaskClient) -> None:
-    """Testing sitemaps.guests"""
+    """Testing sitemaps.guests."""
     response: TestResponse = client.get("/sitemap-guests.xml")
     assert response.status_code == 200
     assert "Content-Type" in response.headers
@@ -29,7 +29,7 @@ def test_guest(client: FlaskClient) -> None:
 
 
 def test_hosts(client: FlaskClient) -> None:
-    """Testing sitemaps.hosts"""
+    """Testing sitemaps.hosts."""
     response: TestResponse = client.get("/sitemap-hosts.xml")
     assert response.status_code == 200
     assert "Content-Type" in response.headers
@@ -39,7 +39,7 @@ def test_hosts(client: FlaskClient) -> None:
 
 
 def test_locations(client: FlaskClient) -> None:
-    """Testing sitemaps.primary"""
+    """Testing sitemaps.primary."""
     response: TestResponse = client.get("/sitemap-locations.xml")
     assert response.status_code == 200
     assert "Content-Type" in response.headers
@@ -49,7 +49,7 @@ def test_locations(client: FlaskClient) -> None:
 
 
 def test_panelists(client: FlaskClient) -> None:
-    """Testing sitemaps.panelists"""
+    """Testing sitemaps.panelists."""
     response: TestResponse = client.get("/sitemap-panelists.xml")
     assert response.status_code == 200
     assert "Content-Type" in response.headers
@@ -59,7 +59,7 @@ def test_panelists(client: FlaskClient) -> None:
 
 
 def test_scorekeepers(client: FlaskClient) -> None:
-    """Testing sitemaps.scorekeepers"""
+    """Testing sitemaps.scorekeepers."""
     response: TestResponse = client.get("/sitemap-scorekeepers.xml")
     assert response.status_code == 200
     assert "Content-Type" in response.headers
@@ -69,7 +69,7 @@ def test_scorekeepers(client: FlaskClient) -> None:
 
 
 def test_shows(client: FlaskClient) -> None:
-    """Testing sitemaps.shows"""
+    """Testing sitemaps.shows."""
     response: TestResponse = client.get("/sitemap-shows.xml")
     assert response.status_code == 200
     assert "Content-Type" in response.headers


### PR DESCRIPTION
## Application Changes

- Add type hints for a majority of the return types for routes and utility modules
- Replace use of `typing.Optional` and `typing.Union` with the with the conventions documented in PEP-484 and PEP-604
- Change handling of `time_zone` configuration value to prevent use of `pytz.timezone()` in function arguments

## Component Changes

- Upgrade wwdtm from 2.6.1 to 2.7.0, which includes:
  - Upgrade numpy from 1.26.0 to 1.26.3
- Upgrade Markdown from 3.5.1 to 3.5.2

## Development Changes

- Switch to Ruff for code linting and formatting (with the help of Black)
- Upgrade pytest from 7.4.3 to 7.4.4
- Upgrade black from 23.11.0 to 23.12.1

## Documentation Changes

- Update the copyright block at the top of each file to remove `coding` line and to include the appropriate SPDX license identifier