### PR TITLE
Add support for show URL field from database and Patreon links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changes
 
+## 5.10.0
+
+### Application Changes
+
+- Add support for new show URL field from the Wait Wait Stats Database, which is used in place of
+  the `/s/` redirect link if there is a value stored for a particular show
+- Add support for Patreon link in the side pop-out nav, dropdown nav menu and in the footer by way
+  of the `settings.patreon_url` config key
+
+### Component Changes
+
+- Upgrade wwdtm from 2.7.0 to 2.8.0
+
 ## 5.9.0
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -60,6 +60,7 @@ def create_app() -> Flask:
     app.jinja_env.globals["mastodon_user"] = _config["settings"].get(
         "mastodon_user", ""
     )
+    app.jinja_env.globals["patreon_url"] = _config["settings"].get("patreon_url", "")
     app.jinja_env.globals["use_decimal_scores"] = _config["settings"][
         "use_decimal_scores"
     ]

--- a/app/shows/templates/shows/all_details.html
+++ b/app/shows/templates/shows/all_details.html
@@ -22,7 +22,13 @@
                                                             month=repeat_show.month,
                                                             day=repeat_show.day) }}">{{ show.original_show_date }}</a></span>
         {% endif %}
-        <span class="show-nprlink"><a href="{{ url_for('main_redirects.npr_show_redirect', show_date=show.date) }}">NPR</a></span>
+        <span class="show-nprlink">
+        {% if show.show_url %}
+        <a href="{{ show.show_url }}">NPR</a>
+        {% else %}
+        <a href="{{ url_for('main_redirects.npr_show_redirect', show_date=show.date) }}">NPR</a>
+        {% endif %}
+        </span>
         <span class="database-id">DB ID: {{ show.id }}</span>
     </div>
 </div>

--- a/app/shows/templates/shows/details.html
+++ b/app/shows/templates/shows/details.html
@@ -19,7 +19,13 @@
                                                               month=repeat_show.month,
                                                               day=repeat_show.day) }}">{{ show.original_show_date }}</a></span>
         {% endif %}
-        <span class="show-nprlink"><a href="{{ url_for('main_redirects.npr_show_redirect', show_date=show.date) }}">NPR</a></span>
+        <span class="show-nprlink">
+        {% if show.show_url %}
+        <a href="{{ show.show_url }}">NPR</a>
+        {% else %}
+        <a href="{{ url_for('main_redirects.npr_show_redirect', show_date=show.date) }}">NPR</a>
+        {% endif %}
+        </span>
         <span class="database-id">DB ID: {{ show.id }}</span>
     </div>
 </div>

--- a/app/templates/core/footer.html
+++ b/app/templates/core/footer.html
@@ -9,6 +9,9 @@
                     <li><a href="{{ blog_url }}">Blog</a></li>
                     <li><a href="{{ graphs_url }}">Graphs</a></li>
                     <li><a href="{{ reports_url }}">Reports</a></li>
+                    {% if patreon_url %}
+                    <li><a href="{{ patreon_url }}">Patreon</a></li>
+                    {% endif %}
                 </ul>
             </div>
         </div>

--- a/app/templates/core/nav.html
+++ b/app/templates/core/nav.html
@@ -15,8 +15,10 @@
             <li><a href="{{ blog_url }}">Blog</a></li>
             <li><a href="{{ graphs_url }}">Graphs</a></li>
             <li><a href="{{ reports_url }}">Reports</a></li>
+            {% if patreon_url %}
             <li class="divider" tabindex="-1"></li>
-            <li><a href="{{ blog_url }}/contact-me/">Contact Me</a></li>
+            <li><a href="{{ patreon_url }}">Patreon</a></li>
+            {% endif %}
         </ul>
         <ul id="nav-mobile" class="right hide-on-med-and-down">
             <li><a href="{{ url_for('guests.index') }}">Guests</a></li>
@@ -53,8 +55,10 @@
         <li><a href="{{ blog_url }}">Blog</a></li>
         <li><a href="{{ graphs_url }}">Graphs</a></li>
         <li><a href="{{ reports_url }}">Reports</a></li>
+        {% if patreon_url %}
         <li><div class="divider"></div></li>
-        <li><a href="{{ blog_url }}/contact-me/">Contact Me</a></li>
+        <li><a href="{{ patreon_url }}">Patreon</a></li>
+        {% endif %}
     </ul>
 </div>
 <!-- End Navigation -->

--- a/app/templates/pages/about.html
+++ b/app/templates/pages/about.html
@@ -18,7 +18,7 @@
 <p>
     The Wait Wait... Don't Tell Me! Stats Page is collection of details
     and statistics for the weekly NPR news quiz show,
-    &quot;<a href="//waitwait.npr.org">Wait Wait... Don't Tell Me!</a>&quot;
+    &quot;<a href="https://waitwait.npr.org">Wait Wait... Don't Tell Me!</a>&quot;
     This site contains data for each of the hosts, panelist, scorekeeper and
     Not My Job guest that has appeared on the show.
 </p>
@@ -47,13 +47,28 @@
 
 <h2>Acknowledgments</h2>
 <p>
-        One of the inspirations that I had when building this site was
-        <a href="http://www.mrkland.com/mrkland.com/passive/WWDTM/index.htm">mrk.'s
-        Wait Wait Don't Tell Me Statistics Pages</a> 
-        (<a href="https://web.archive.org/web/20190404122827/http://www.mrkland.com/zone/WWDTM/index.htm">Internet
-        Archive</a>). I used some of the scoring data from that site
-        to fill in some of the informational blanks for some of the shows prior
-        to Peter Sagal becoming the show's host.
+    One of the inspirations that I had when building this site was
+    <a href="http://www.mrkland.com/mrkland.com/passive/WWDTM/index.htm">mrk.'s
+    Wait Wait Don't Tell Me Statistics Pages</a> 
+    (<a href="https://web.archive.org/web/20190404122827/http://www.mrkland.com/zone/WWDTM/index.htm">Internet
+    Archive</a>). I used some of the scoring data from that site
+    to fill in some of the informational blanks for some of the shows prior
+    to Peter Sagal becoming the show's host.
 </p>
+
+<p>
+    I would also like to thank David Moss for providing a list of the direct
+    links for each show page on NPR.org for the shows from 2006 through 2023.
+</p>
+
+{% if patreon_url %}
+<h2>Supporting the Wait Wait Stats Project</h2>
+<p>
+    If you would like to help support the Wait Wait Stats Project, including
+    improvements, new features, or help cover the host of hosting and maintaining
+    the Wait Wait Stats applications, consider supporting me on
+    <a href="{{ patreon_url }}">Patreon</a>.
+</p>
+{% endif %}
 
 {% endblock %}

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "5.9.0"
+APP_VERSION = "5.10.0"

--- a/config.json.dist
+++ b/config.json.dist
@@ -23,6 +23,7 @@
         "time_zone": "UTC",
         "mastodon_url": "",
         "mastodon_user": "",
+        "patreon_url": "",
         "sort_by_venue": false,
         "use_decimal_scores": false
     }

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ Flask==3.0.0
 gunicorn==21.2.0
 Markdown==3.5.2
 
-wwdtm==2.7.0
+wwdtm==2.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==3.0.0
 gunicorn==21.2.0
 Markdown==3.5.2
 
-wwdtm==2.7.0
+wwdtm==2.8.0


### PR DESCRIPTION
## Application Changes

- Add support for new show URL field from the Wait Wait Stats Database, which is used in place of the `/s/` redirect link if there is a value stored for a particular show
- Add support for Patreon link in the side pop-out nav, dropdown nav menu and in the footer by way of the `settings.patreon_url` config key

## Component Changes

- Upgrade wwdtm from 2.7.0 to 2.8.0