### PR TITLE
Add GitHub Sponsor link support and footer rendering update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
 # Changes
 
+## 5.10.1
+
+### Application Changes
+
+- Add support for GitHub sponsorship link in the side pop-out nav, dropdown nav menu and in the footer by way of the `settings.github_sponsor_url` config key
+- Change the how render and version information is rendered on screens with a width less than 1200px to align left rather than right
+
 ## 5.10.0
 
 ### Application Changes
 
-- Add support for new show URL field from the Wait Wait Stats Database, which is used in place of
-  the `/s/` redirect link if there is a value stored for a particular show
-- Add support for Patreon link in the side pop-out nav, dropdown nav menu and in the footer by way
-  of the `settings.patreon_url` config key
+- Add support for new show URL field from the Wait Wait Stats Database, which is used in place of the `/s/` redirect link if there is a value stored for a particular show
+- Add support for Patreon link in the side pop-out nav, dropdown nav menu and in the footer by way of the `settings.patreon_url` config key
 
 ### Component Changes
 

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -61,6 +61,9 @@ def create_app() -> Flask:
         "mastodon_user", ""
     )
     app.jinja_env.globals["patreon_url"] = _config["settings"].get("patreon_url", "")
+    app.jinja_env.globals["github_sponsor_url"] = _config["settings"].get(
+        "github_sponsor_url", ""
+    )
     app.jinja_env.globals["use_decimal_scores"] = _config["settings"][
         "use_decimal_scores"
     ]

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -24,6 +24,8 @@
     .container { max-width: initial; width: 95%; }
     .dropdown-content { border: 2px solid rgba(0, 0, 0, 0.1); }
     .dropdown-content li>a, .dropdown-content li>span { color: initial; }
+    .sidenav li>a.subheader { cursor: initial; text-transform: uppercase; font-size: 0.9rem; font-weight: bold; pointer-events: none;}
+    .dropdown-content li.subheader>a { cursor: initial; text-transform: uppercase; font-size: 0.825rem; font-weight: bold; pointer-events: none;}
     .page-breadcrumb { background-color: rgba(96, 96, 96, 0.05); margin: 1.25rem 0; padding: 0.25rem 1rem; }
     .page-breadcrumb ul { list-style: none; padding: 0; }
     .page-breadcrumb ul li { display: inline; padding: 0; }
@@ -67,6 +69,9 @@
     .show-nprlink { background-color: #3366cc; color: white; }
     .show-nprlink>a { border-bottom: none !important; color: white; }
     .show-nprlink>a::after { content: " \2192"; }
+    #app-copyright, #app-version { display: inline-block; padding: 0.5rem 0; }
+    #app-copyright { float: left; }
+    #app-version { float: right; }
     .traceback { border: 2px solid rgba(0, 0, 0, 0.25); font-size: 90%; overflow: scroll; padding: 1.5rem; width: 100%; }
 }
 
@@ -79,7 +84,8 @@
     html, main, button, input, select, textarea, .collection, .collection-item { background-color: #202124 !important; color: white !important; }
     nav, nav ul a, .brand-logo, .page-footer, .footer-copyright, .nav-wrapper, .sidenav li>a { color: white !important; }
     nav ul a { transition: background-color 0s; }
-    nav ul.dropdown-content a:hover, .sidenav li>a:hover { background-color: rgba(240, 240, 240, 0.5); color: #323438 !important; }
+    nav ul.dropdown-content a:hover, .sidenav li>a:hover, .dropdown-content li>a:hover { background-color: rgba(240, 240, 240, 0.5); color: #323438 !important; }
+    .dropdown-content li.subheader:hover { background-color: inherit; font-weight: bold; }
     main a { color: #64b5f6 !important; }
     div.label { border-bottom: 2px solid rgba(240, 240, 240, 0.5); }
     .collection, .collection-item { border-color: rgba(240, 240, 240, 0.5) !important; }
@@ -91,6 +97,11 @@
     .database-id, .show-nprlink>a { border-bottom: none !important; color: white !important; }
     .show-repeat>a { color: #26323b !important; }
     .sidenav, .sidenav ul, ul.dropdown-content { background-color: #323438 !important; }
+}
+
+@media only screen and (max-width: 1200px) {
+    #app-copyright, #app-version { float: none; }
+    #app-version { clear: both; display: block; }
 }
 
 @media only screen and (max-width: 1024px) {

--- a/app/templates/core/footer.html
+++ b/app/templates/core/footer.html
@@ -9,8 +9,8 @@
                     <li><a href="{{ blog_url }}">Blog</a></li>
                     <li><a href="{{ graphs_url }}">Graphs</a></li>
                     <li><a href="{{ reports_url }}">Reports</a></li>
-                    {% if patreon_url %}
-                    <li><a href="{{ patreon_url }}">Patreon</a></li>
+                    {% if github_sponsor_url or patreon_url %}
+                    <li><a href="{{ url_for('main.about') }}#support-stats">Support Wait Wait Stats</a></li>
                     {% endif %}
                 </ul>
             </div>
@@ -18,14 +18,16 @@
     </div>
     <div class="footer-copyright">
         <div class="container">
-            Copyright &copy; 2007&ndash;{{ current_year(time_zone) }}
-            {% if mastodon_url and mastodon_user %}
-            <a href="https://linhpham.org/">Linh Pham</a> (<a rel="me" href="{{ mastodon_url }}">{{ mastodon_user }}</a>).
-            {% else %}
-            <a href="https://linhpham.org/">Linh Pham</a>.
-            {% endif %}
-            All rights reserved.
-            <span class="right">
+            <span id="app-copyright">
+                Copyright &copy; 2007&ndash;{{ current_year(time_zone) }}
+                {% if mastodon_url and mastodon_user %}
+                <a href="https://linhpham.org/">Linh Pham</a> (<a rel="me" href="{{ mastodon_url }}">{{ mastodon_user }}</a>).
+                {% else %}
+                <a href="https://linhpham.org/">Linh Pham</a>.
+                {% endif %}
+                All rights reserved.
+            </span>
+            <span id="app-version">
                 <span title="Page Rendered at Time">R: {{ rendered_at(time_zone) }}</span> |
                 <span title="Application Version">V: {{ app_version }}</span> |
                 <span title="wwdtm Version">L: {{ wwdtm_version }}</span>

--- a/app/templates/core/nav.html
+++ b/app/templates/core/nav.html
@@ -15,9 +15,15 @@
             <li><a href="{{ blog_url }}">Blog</a></li>
             <li><a href="{{ graphs_url }}">Graphs</a></li>
             <li><a href="{{ reports_url }}">Reports</a></li>
-            {% if patreon_url %}
+            {% if github_sponsor_url or patreon_url %}
             <li class="divider" tabindex="-1"></li>
+            <li class="subheader"><a>Support Wait Wait Stats</a></li>
+                {% if github_sponsor_url %}
+            <li><a href="{{ github_sponsor_url }}">GitHub Sponsor</a></li>
+                {% endif %}
+                {% if patreon_url %}
             <li><a href="{{ patreon_url }}">Patreon</a></li>
+                {% endif %}
             {% endif %}
         </ul>
         <ul id="nav-mobile" class="right hide-on-med-and-down">
@@ -55,9 +61,15 @@
         <li><a href="{{ blog_url }}">Blog</a></li>
         <li><a href="{{ graphs_url }}">Graphs</a></li>
         <li><a href="{{ reports_url }}">Reports</a></li>
-        {% if patreon_url %}
+        {% if github_sponsor_url or patreon_url %}
         <li><div class="divider"></div></li>
+        <li><a class="subheader">Support Wait Wait Stats</a></li>
+            {% if github_sponsor_url %}
+        <li><a href="{{ github_sponsor_url }}">GitHub Sponsor</a></li>
+            {% endif %}
+            {% if patreon_url %}
         <li><a href="{{ patreon_url }}">Patreon</a></li>
+            {% endif %}
         {% endif %}
     </ul>
 </div>

--- a/app/templates/pages/about.html
+++ b/app/templates/pages/about.html
@@ -61,13 +61,20 @@
     links for each show page on NPR.org for the shows from 2006 through 2023.
 </p>
 
-{% if patreon_url %}
-<h2>Supporting the Wait Wait Stats Project</h2>
+{% if github_sponsor_url or patreon_url %}
+<h2 id="support-stats">Support the Wait Wait Stats Project</h2>
+
 <p>
     If you would like to help support the Wait Wait Stats Project, including
     improvements, new features, or help cover the host of hosting and maintaining
     the Wait Wait Stats applications, consider supporting me on
+    {% if github_sponsor_url and patreon_url %}
+    <a href="{{ github_sponsor_url }}">GitHub</a> or <a href="{{ patreon_url }}">Patreon</a>.
+    {% elif patreon_url %}
     <a href="{{ patreon_url }}">Patreon</a>.
+    {% elif github_sponsor_url %}
+    <a href="{{ github_sponsor_url }}">GitHub</a>.
+    {% endif %}
 </p>
 {% endif %}
 

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "5.10.0"
+APP_VERSION = "5.10.1"

--- a/config.json.dist
+++ b/config.json.dist
@@ -24,6 +24,7 @@
         "mastodon_url": "",
         "mastodon_user": "",
         "patreon_url": "",
+        "github_sponsor_url": "",
         "sort_by_venue": false,
         "use_decimal_scores": false
     }


### PR DESCRIPTION
## Application Changes

- Add support for GitHub sponsorship link in the side pop-out nav, dropdown nav menu and in the footer by way of the `settings.github_sponsor_url` config key
- Change the how render and version information is rendered on screens with a width less than 1200px to align left rather than right