### PR TITLE
Fix sorting of panelists by decimal scores for show details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 5.10.2
+
+## Component Changes
+
+- Upgrade wwdtm from 2.8.0 to 2.8.1, which includes fixing an issue of panelists not being sorted by their decimal scores properly
+
 ## 5.10.1
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 5.10.2
 
-## Component Changes
+### Component Changes
 
 - Upgrade wwdtm from 2.8.0 to 2.8.1, which includes fixing an issue of panelists not being sorted by their decimal scores properly
 

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "5.10.1"
+APP_VERSION = "5.10.2"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ Flask==3.0.0
 gunicorn==21.2.0
 Markdown==3.5.2
 
-wwdtm==2.8.0
+wwdtm==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==3.0.0
 gunicorn==21.2.0
 Markdown==3.5.2
 
-wwdtm==2.8.0
+wwdtm==2.8.1


### PR DESCRIPTION
## Component Changes

- Upgrade wwdtm from 2.8.0 to 2.8.1, which includes fixing an issue of panelists not being sorted by their decimal scores properly