### PR TITLE
Bump flask, gunicorn, ruff and pytest dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changes
 
+## 5.10.4
+
+### Component Changes
+
+- Upgrade wwdtm from 2.8.1 to 2.8.2
+- Upgrade flask from 3.0.0 to 3.0.3
+- Upgrade gunicorn from 21.2.0 to 22.0.0
+
+### Development Changes
+
+- Upgrade ruff from 0.1.13 to 0.3.6
+- Upgrade pytest from 7.4.4 to 8.1.1
+
 ## 5.10.3
 
 ### Development Changes

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "5.10.3"
+APP_VERSION = "5.10.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,40 @@ norecursedirs = [
 
 [tool.ruff]
 target-version = "py310"
+
+exclude = [
+    "migrations",
+    "__pycache__",
+    "manage.py",
+    "settings.py",
+    "env",
+    ".env",
+    "venv",
+    ".venv",
+]
+
+line-length = 88 # Must agree with Black
+
+[tool.ruff.lint]
+ignore = [
+    "B905",   # zip strict=True; remove once python <3.10 support is dropped.
+    "D100",
+    "D101",
+    "D102",
+    "D103",
+    "D104",
+    "D105",
+    "D106",
+    "D107",
+    "D200",
+    "D401",
+    "E402",
+    "E501",
+    "F401",
+    "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
+    "S608",
+]
+
 select = [
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
@@ -38,44 +72,13 @@ select = [
     "YTT", # flake8-2020
 ]
 
-exclude = [
-    "migrations",
-    "__pycache__",
-    "manage.py",
-    "settings.py",
-    "env",
-    ".env",
-    "venv",
-    ".venv",
-]
-
-ignore = [
-    "B905",   # zip strict=True; remove once python <3.10 support is dropped.
-    "D100",
-    "D101",
-    "D102",
-    "D103",
-    "D104",
-    "D105",
-    "D106",
-    "D107",
-    "D200",
-    "D401",
-    "E402",
-    "E501",
-    "F401",
-    "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
-    "S608",
-]
-line-length = 88 # Must agree with Black
-
-[tool.ruff.flake8-bugbear]
+[tool.ruff.lint.flake8-bugbear]
 extend-immutable-calls = ["chr", "typer.Argument", "typer.Option"]
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "pep257"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "tests/*.py" = [
     "D100",
     "D101",
@@ -90,5 +93,5 @@ convention = "pep257"
     "S106",   # possible hardcoded password.
 ]
 
-[tool.ruff.pep8-naming]
+[tool.ruff.lint.pep8-naming]
 staticmethod-decorators = ["pydantic.validator", "pydantic.root_validator"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
-ruff==0.1.13
+ruff==0.3.6
 black==24.3.0
-pytest==7.4.4
+pytest==8.1.1
 
-Flask==3.0.0
-gunicorn==21.2.0
+Flask==3.0.3
+gunicorn==22.0.0
 Markdown==3.5.2
 
-wwdtm==2.8.1
+wwdtm==2.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-Flask==3.0.0
-gunicorn==21.2.0
+Flask==3.0.3
+gunicorn==22.0.0
 Markdown==3.5.2
 
-wwdtm==2.8.1
+wwdtm==2.8.2


### PR DESCRIPTION
## Component Changes

- Upgrade wwdtm from 2.8.0 to 2.8.2
- Upgrade flask from 3.0.0 to 3.0.3
- Upgrade gunicorn from 21.2.0 to 22.0.0

## Development Changes

- Upgrade ruff from 0.1.13 to 0.3.6
- Upgrade pytest from 7.4.4 to 8.1.1