### PR TITLE
Change z-index of map controls, set font-family to inherit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 5.11.1
+
+### Application Changes
+
+- Change the z-index for the map control area to `500` to prevent the controls from appearing over slide-out navigation or pop-up menus
+- Update styles for Leaflet to inherit font-family used for the rest of the application (IBM Plex Sans)
+
 ## 5.11.0
 
 ### Application Changes

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -71,9 +71,11 @@
     .show-nprlink>a { border-bottom: none !important; color: white; }
     .show-nprlink>a::after { content: " \2192"; }
     #map { height: 75vh; margin: 0.5rem auto; }
+    .leaflet-container, .leaflet-control-zoom-in, .leaflet-control-zoom-out { font-family: inherit !important; }
     #map a::after { content: none; }
     #map a, #map a:link, #map a:hover, #map a:active, #map a:visited { color: #0d47a1 !important; }
     #map .leaflet-control-zoom a, #map .leaflet-control-zoom a:link, #map .leaflet-control-zoom a:hover, #map .leaflet-control-zoom a:active, #map .leaflet-control-zoom a:visited { color: #444 !important; }
+    #map .leaflet-top, #map .leaflet-bottom { z-index: 500 !important; }
     #app-copyright, #app-version { display: inline-block; padding: 0.5rem 0; }
     #app-copyright { float: left; }
     #app-version { float: right; }

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "5.11.0"
+APP_VERSION = "5.11.1"


### PR DESCRIPTION
## Application Changes

- Change the z-index for the map control area to `500` to prevent the controls from appearing over slide-out navigation or pop-up menus
- Update styles for Leaflet to inherit font-family used for the rest of the application (IBM Plex Sans)