### PR TITLE
Add labels (aka tags) for host, panelist and scorekeeper preferred pronouns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Application Changes
 
-- Add support for host, panelist and scorekeeper pronouns via a label next to the corresponding ID label in their details page
+- Add support for host, panelist and scorekeeper preferred pronouns via a label (aka tag) next to the corresponding ID label in their details page
 
 ## 5.11.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 5.12.0
+
+### Application Changes
+
+- Add support for host, panelist and scorekeeper pronouns via a label next to the corresponding ID label in their details page
+
 ## 5.11.3
 
 ### Component Changes

--- a/app/hosts/templates/hosts/details.html
+++ b/app/hosts/templates/hosts/details.html
@@ -8,6 +8,9 @@
 <div class="row host-badges">
     <div class="col s12">
         <span class="database-id">DB ID: {{ host.id }}</span>
+        {% if host.pronouns %}
+        <span class="host-pronouns">Pronouns: {{ host.pronouns|join("/")}}</span>
+        {% endif %}
     </div>
 </div>
 <div class="row">

--- a/app/panelists/templates/panelists/details.html
+++ b/app/panelists/templates/panelists/details.html
@@ -7,6 +7,9 @@
 <div class="row panelist-badges">
     <div class="col s12">
         <span class="database-id">DB ID: {{ panelist.id }}</span>
+        {% if panelist.pronouns %}
+        <span class="panelist-pronouns">Pronouns: {{ panelist.pronouns|join("/")}}</span>
+        {% endif %}
     </div>
 </div>
 

--- a/app/scorekeepers/templates/scorekeepers/details.html
+++ b/app/scorekeepers/templates/scorekeepers/details.html
@@ -11,6 +11,9 @@
         <span class="scorekeeper-emeritus">Scorekeeper Emeritus</span>
         {% endif %}
         <span class="database-id">DB ID: {{ scorekeeper.id }}</span>
+        {% if scorekeeper.pronouns %}
+        <span class="scorekeeper-pronouns">Pronouns: {{ scorekeeper.pronouns|join("/")}}</span>
+        {% endif %}
     </div>
 </div>
 

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -39,7 +39,7 @@
     .data-tbd, .data-na, .data-multiple { font-style: italic; }
     .database-id { background-color: #393b40; color: #eceff1; }
     .scorekeeper-emeritus { background-color: #c5cae9; }
-    .database-id, .show-bestof, .show-repeat, .scorekeeper-emeritus, .show-nprlink { font-weight: 500; padding: 0.25rem 1rem; margin-right: 0.5rem; }    
+    .database-id, .show-bestof, .show-repeat, .scorekeeper-emeritus, .show-nprlink, .host-pronouns, .panelist-pronouns, .scorekeeper-pronouns { font-weight: 500; padding: 0.25rem 1rem; margin-right: 0.5rem; }
     ul.footer-nav-links { list-style: none; margin: 0; padding: 0; }
     ul.footer-nav-links li { display: inline; margin: 0 0.5rem; padding: 0; }
     .guest-appearance-list>ul, .host-appearance-list>ul, .location-appearance-list>ul, .panelist-appearance-list>ul, .scorekeeper-appearance-list>ul { column-count: 2; column-fill: balance; column-rule: 1px dotted rgba(0, 0, 0, 0.25); line-height: 2.5; list-style: none; margin: 0; padding: 0; }
@@ -49,6 +49,7 @@
     .guest-block a::after, .host-block a::after, .location-block a::after, .panelist-block a::after, .scorekeeper-block a::after, .show-block a::after { content: " \2192"; }
     .guest-show-bestof, .host-show-bestof, .location-show-bestof, .panelist-show-bestof, .scorekeeper-show-bestof, .show-bestof { background-color: #bbdefb; }
     .guest-show-repeat, .host-show-repeat, .location-show-repeat, .panelist-show-repeat, .scorekeeper-show-repeat, .show-repeat { background-color: #ffe0b2; }
+    .host-pronouns, .panelist-pronouns, .scorekeeper-pronouns { background-color: #b2dfdb;}
     .host-guest, .scorekeeper-guest { background-color: #c8e6c9; color: #242f39; font-weight: 500; padding: 0.2rem 0.5rem; margin: 0 0.25rem; }
     .guest-show-repeat>a, .host-show-repeat>a, .location-show-repeat>a, .panelist-show-repeat>a, .scorekeeper-show-repeat>a { border-bottom: none !important; }
     .host-appearance-list>ul, .location-appearance-list>ul, .panelist-appearance-list>ul, .scorekeeper-appearance-list>ul { column-count: 3; column-fill: balance; }
@@ -102,7 +103,7 @@
     .footer-copyright { background-color: #072C64 !important; }
     .guest-block, .host-block, .location-block, .panelist-block, .scorekeeper-block, .show-block { border-left: 4px solid rgba(240, 240, 240, 0.5); }
     .guest-appearance-list>ul, .host-appearance-list>ul, .location-appearance-list>ul, .panelist-appearance-list>ul, .scorekeeper-appearance-list>ul { column-rule: 1px dotted rgba(240, 240, 240, 0.5); }
-    .guest-show-bestof, .guest-show-repeat, .host-show-bestof, .host-show-repeat, .location-show-bestof, .location-show-repeat, .panelist-show-bestof, .panelist-show-repeat, .scorekeeper-emeritus, .scorekeeper-show-bestof, .scorekeeper-show-repeat, .show-bestof, .show-repeat { color: #242f39 }
+    .guest-show-bestof, .guest-show-repeat, .host-show-bestof, .host-show-repeat, .host-pronouns, .location-show-bestof, .location-show-repeat, .panelist-show-bestof, .panelist-show-repeat, .panelist-pronouns, .scorekeeper-emeritus, .scorekeeper-show-bestof, .scorekeeper-show-repeat, .scorekeeper-pronouns, .show-bestof, .show-repeat { color: #242f39 }
     .database-id, .show-nprlink>a { border-bottom: none !important; color: white !important; }
     .show-repeat>a { color: #26323b !important; }
     .sidenav, .sidenav ul, ul.dropdown-content { background-color: #323438 !important; }

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "5.11.3"
+APP_VERSION = "5.12.0"


### PR DESCRIPTION
## Application Changes

- Add support for host, panelist and scorekeeper preferred pronouns via a label (aka tag) next to the corresponding ID label in their details page