### PR TITLE
Add support for Umami web analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Ruff
+.ruff_cache
+
 # Distribution / packaging
 .Python
 build/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 | `data_host_url` | Override the location where Umami data is sent to |
 | `data_domains` | Comma-delimited list of domains where the Umami script should be active |
 
-## Component Changes
+### Component Changes
 
 - Upgrade wwdtm 2.10.0 to 2.10.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,16 @@
 
 ### Application Changes
 
-- Add support for Umami Analytics via `settings.umami_analytics` config key
+- Add support for Umami web analytics via `settings.umami_analytics` config object with the following keys:
+
+| Config Key | Description |
+| ---------- | ----------- |
+| `_enabled` | Set value to `true` to enable adding Umami `script` tag (default: `false`) |
+| `url` | URL of the Umami analytics script |
+| `data_website_id` | Umami Site ID |
+| `data_auto_track` | Set value to `false` to disable auto event tracking (default: `true`) |
+| `data_host_url` | Override the location where Umami data is sent to |
+| `data_domains` | Comma-delimited list of domains where the Umami script should be active |
 
 ## Component Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changes
 
+## 5.13.0
+
+### Application Changes
+
+- Add support for Umami Analytics via `settings.umami_analytics` config key
+
+## Component Changes
+
+- Upgrade wwdtm 2.10.0 to 2.10.1
+
+### Development Changes
+
+- Upgrade ruff from 0.3.6 to 0.5.1
+- Upgrade black from 24.3.0 to 24.4.2
+- Upgrade pytest from 8.1.1 to 8.1.2
+
 ## 5.12.1
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -20,8 +20,11 @@ from app.shows.routes import blueprint as shows_bp
 from app.sitemaps.routes import blueprint as sitemaps_bp
 from app.version import APP_VERSION
 
+from .utility import format_umami_analytics
+
 
 def create_app() -> Flask:
+    """Create Flask application."""
     app = Flask(__name__)
     app.url_map.strict_slashes = False
 
@@ -50,6 +53,10 @@ def create_app() -> Flask:
     app.jinja_env.globals["time_zone"] = _config["settings"]["time_zone"]
     app.jinja_env.globals["ga_property_code"] = _config["settings"].get(
         "ga_property_code", ""
+    )
+    umami = _config["settings"].get("umami_analytics", None)
+    app.jinja_env.globals["umami_analytics"] = format_umami_analytics(
+        umami_analytics=umami
     )
     app.jinja_env.globals["api_url"] = _config["settings"].get("api_url", "")
     app.jinja_env.globals["blog_url"] = _config["settings"].get("blog_url", "")

--- a/app/config.py
+++ b/app/config.py
@@ -20,6 +20,7 @@ def load_config(
     connection_pool_name: str = "wwdtm_stats",
     app_time_zone: str = "UTC",
 ) -> dict[str, dict[str, Any]]:
+    """Read configuration and database settings."""
     _config_file_path = Path(config_file_path)
     with _config_file_path.open(mode="r", encoding="utf-8") as config_file:
         app_config = json.load(config_file)

--- a/app/dicts.py
+++ b/app/dicts.py
@@ -5,7 +5,6 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Dictionary objects used by the Wait Wait Stats Page."""
 import mysql.connector
-from flask import current_app
 
 PANELIST_RANKS: dict[str, str] = {
     "1": "First",

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,6 +14,11 @@
     gtag('config', '{{ ga_property_code }}');
     </script>
     {% endif %}
+
+    {% if umami_analytics %}
+    <!-- Umami Analytics -->
+    {{ umami_analytics|safe }}
+    {% endif %}
 </head>
 <body>
 {% include "core/nav.html" %}

--- a/app/utility.py
+++ b/app/utility.py
@@ -12,6 +12,28 @@ import pytz
 from flask import current_app
 
 
+def format_umami_analytics(umami_analytics: dict = None) -> str:
+    """Return formatted string for Umami Analytics."""
+    if not umami_analytics:
+        return None
+
+    url = umami_analytics.get("url")
+    website_id = umami_analytics.get("data_website_id")
+    auto_track = bool(umami_analytics.get("data_auto_track", True))
+    host_url = umami_analytics.get("data_host_url")
+    domains = umami_analytics.get("data_domains")
+
+    if url and website_id:
+        host_url_prop = f'data_host_url="{host_url}"' if host_url else ""
+        auto_track_prop = f'data_auto_track="{str(auto_track).lower()}"'
+        domains_prop = f'data_domains="{domains}"' if domains else ""
+
+        props = " ".join([host_url_prop, auto_track_prop, domains_prop])
+        return f'<script defer src="{url}" data_website_id="{website_id}" {props.strip()}></script>'
+
+    return None
+
+
 def current_year(time_zone: str = "UTC") -> str:
     """Return the current year."""
     _time_zone = pytz.timezone(time_zone)

--- a/app/utility.py
+++ b/app/utility.py
@@ -17,6 +17,11 @@ def format_umami_analytics(umami_analytics: dict = None) -> str:
     if not umami_analytics:
         return None
 
+    _enabled = bool(umami_analytics.get("_enabled", False))
+
+    if not _enabled:
+        return None
+
     url = umami_analytics.get("url")
     website_id = umami_analytics.get("data_website_id")
     auto_track = bool(umami_analytics.get("data_auto_track", True))

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "5.12.1"
+APP_VERSION = "5.13.0"

--- a/config.json.dist
+++ b/config.json.dist
@@ -19,6 +19,7 @@
         "site_url": "",
         "ga_property_code": null,
         "umami_analytics": {
+            "_enabled": false,
             "url": "",
             "data_website_id": "",
             "data_domains": "",

--- a/config.json.dist
+++ b/config.json.dist
@@ -18,6 +18,13 @@
         "reports_url": "",
         "site_url": "",
         "ga_property_code": null,
+        "umami_analytics": {
+            "url": "",
+            "data_website_id": "",
+            "data_domains": "",
+            "data_host_url": "",
+            "data_auto_track": true
+        }
         "recent_days_ahead": 1,
         "recent_days_back": 31,
         "time_zone": "UTC",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-required-version = "24.3.0"
+required-version = "24.4.2"
 target-version = ["py310", "py311", "py312"]
 line-length = 88
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,9 +1,9 @@
-ruff==0.3.6
-black==24.3.0
-pytest==8.1.1
+ruff==0.5.1
+black==24.4.2
+pytest==8.1.2
 
 Flask==3.0.3
 gunicorn==22.0.0
 Markdown==3.5.2
 
-wwdtm==2.10.0
+wwdtm==2.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==3.0.3
 gunicorn==22.0.0
 Markdown==3.5.2
 
-wwdtm==2.10.0
+wwdtm==2.10.1


### PR DESCRIPTION
## Application Changes

- Add support for Umami web analytics via `settings.umami_analytics` config object with the following keys:

| Config Key | Description |
| ---------- | ----------- |
| `_enabled` | Set value to `true` to enable adding Umami `script` tag (default: `false`) |
| `url` | URL of the Umami analytics script |
| `data_website_id` | Umami Site ID |
| `data_auto_track` | Set value to `false` to disable auto event tracking (default: `true`) |
| `data_host_url` | Override the location where Umami data is sent to |
| `data_domains` | Comma-delimited list of domains where the Umami script should be active |

## Component Changes

- Upgrade wwdtm 2.10.0 to 2.10.1

## Development Changes

- Upgrade ruff from 0.3.6 to 0.5.1
- Upgrade black from 24.3.0 to 24.4.2
- Upgrade pytest from 8.1.1 to 8.1.2