### PR TITLE
Add Umami script tag to errors base template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 5.13.2
+
+### Application Changes
+
+- Add Umami `script` tag to errors base template
+
 ## 5.13.1
 
 ### Application Changes

--- a/app/templates/errors/base.html
+++ b/app/templates/errors/base.html
@@ -14,6 +14,11 @@
     gtag('config', '{{ ga_property_code }}');
     </script>
     {% endif %}
+
+    {% if umami_analytics %}
+    <!-- Umami Analytics -->
+    {{ umami_analytics|safe }}
+    {% endif %}
 </head>
 <body>
 <main>

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "5.13.1"
+APP_VERSION = "5.13.2"


### PR DESCRIPTION
## Application Changes

- Add Umami `script` tag to errors base template