### PR TITLE
Move Google and Umami analytics to base.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 5.13.3
+
+### Application Changes
+
+- Move web analytics tags out of `base.html` into `head.html`
+
 ## 5.13.2
 
 ### Application Changes

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,22 +3,6 @@
 <head>
     <title>{% block title %}{% endblock %} | Wait Wait Don't Tell Me! Stats Page</title>
     {% include "core/head.html" with context %}
-
-    {% if ga_property_code %}
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga_property_code }}"></script>
-    <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', '{{ ga_property_code }}');
-    </script>
-    {% endif %}
-
-    {% if umami_analytics %}
-    <!-- Umami Analytics -->
-    {{ umami_analytics|safe }}
-    {% endif %}
 </head>
 <body>
 {% include "core/nav.html" %}

--- a/app/templates/core/head.html
+++ b/app/templates/core/head.html
@@ -21,3 +21,19 @@
     <!-- Import Leaflet -->
     <link rel="stylesheet" href="{{ url_for('static', filename='leaflet/leaflet.css') }}">
     <script src="{{ url_for('static', filename='leaflet/leaflet.js')}}"></script>
+
+    {% if ga_property_code %}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id={{ ga_property_code }}"></script>
+    <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', '{{ ga_property_code }}');
+    </script>
+    {% endif %}
+
+    {% if umami_analytics %}
+    <!-- Umami Analytics -->
+    {{ umami_analytics|safe }}
+    {% endif %}

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "5.13.2"
+APP_VERSION = "5.13.3"


### PR DESCRIPTION
## Application Changes

- Move web analytics tags out of `base.html` into `head.html`