### PR TITLE
Update GitHub repo references to stats.wwdt.me instead of stats.wwdt.me_v5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 5.13.4
+
+### Application Changes
+
+- Update references to GitHub repository to point to [stats.wwdt.me](https://github.com/questionlp/stats.wwdt.me) instead of `stats.wwdt.me_v5`.
+
 ## 5.13.3
 
 ### Application Changes

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -9,7 +9,7 @@ This document provides instructions on how to serve the application through [Gun
 Clone a copy of this repository to a location of your choosing by running:
 
 ```bash
-git clone https://github.com/questionlp/stats.wwdt.me_v5.git
+git clone https://github.com/questionlp/stats.wwdt.me.git
 ```
 
 Within the new local copy of the repository, create a new virtual environment and install the required packages by running the following commands:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Wait Wait Don't Tell Me! Stats and Details Site
 
+**Note:** This project's repository has been renamed from `stats.wwdt.me_v5` to `stats.wwdt.me`. Please make sure that you update your `.git/config` accordingly. The `stats.wwdt.me_v5` repository on GitHub is now just a placeholder repository.
+
 ## Overview
 
 Flask-based web application that serves up statistics and details for the NPR weekly quiz show [Wait Wait... Don't Tell Me!](http://waitwait.npr.org)

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1,7 +1,7 @@
 /*!
- * stats.wwdt.me (https://github.com/questionlp/stats.wwdt.me_v5)
+ * stats.wwdt.me (https://github.com/questionlp/stats.wwdt.me)
  * Copyright 2018-2024 Linh Pham
- * Apache License 2.0 (https://github.com/questionlp/stats.wwdt.me_v5/blob/main/LICENSE)
+ * Apache License 2.0 (https://github.com/questionlp/stats.wwdt.me/blob/main/LICENSE)
  */
 
 @media all {

--- a/app/static/js/init.js
+++ b/app/static/js/init.js
@@ -1,7 +1,7 @@
 /*!
- * stats.wwdt.me (https://github.com/questionlp/stats.wwdt.me_v5)
+ * stats.wwdt.me (https://github.com/questionlp/stats.wwdt.me)
  * Copyright 2018-2024 Linh Pham
- * Apache License 2.0 (https://github.com/questionlp/stats.wwdt.me_v5/blob/main/LICENSE)
+ * Apache License 2.0 (https://github.com/questionlp/stats.wwdt.me/blob/main/LICENSE)
  */
 
 document.addEventListener('DOMContentLoaded', function () {

--- a/app/static/js/location-map.js
+++ b/app/static/js/location-map.js
@@ -1,7 +1,7 @@
 /*!
- * stats.wwdt.me (https://github.com/questionlp/stats.wwdt.me_v5)
+ * stats.wwdt.me (https://github.com/questionlp/stats.wwdt.me)
  * Copyright 2018-2024 Linh Pham, Elijah Conners
- * Apache License 2.0 (https://github.com/questionlp/stats.wwdt.me_v5/blob/main/LICENSE)
+ * Apache License 2.0 (https://github.com/questionlp/stats.wwdt.me/blob/main/LICENSE)
  */
 
 if (document.getElementById("map")) {

--- a/app/templates/pages/about.html
+++ b/app/templates/pages/about.html
@@ -42,7 +42,7 @@
     The source code for this site is released under the terms of 
     <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache
     License 2.0</a> and is available on
-    <a href="https://github.com/questionlp/stats.wwdt.me_v5">GitHub</a>.
+    <a href="https://github.com/questionlp/stats.wwdt.me">GitHub</a>.
 </p>
 
 <h2>Acknowledgments</h2>

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "5.13.3"
+APP_VERSION = "5.13.4"


### PR DESCRIPTION
## Application Changes

- Update references to GitHub repository to point to [stats.wwdt.me](https://github.com/questionlp/stats.wwdt.me) instead of `stats.wwdt.me_v5`.