### PR TITLE
Fix Issue with Panelist Details Route

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,3 @@
+[design]
+max-locals = 20
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 6.0.1
+
+### Application Changes
+
+- Fix an error caused by checking the wrong variable for `panelists.routes.details()`
+
 ## 6.0.0-post0
 
 ### Application Changes

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -59,7 +59,7 @@ def details(panelist_slug: str) -> Response | str:
     )
     database_connection.close()
 
-    if not details:
+    if not _details:
         return redirect(url_for("panelists.index"))
 
     panelists = []

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "6.0.0"
+APP_VERSION = "6.0.1"


### PR DESCRIPTION
## Application Changes

- Fix an error caused by checking the wrong variable for `panelists.routes.details()`