### PR TITLE
Fix issues with locations ordering, recording list and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changes
 
+## 6.0.2
+
+### Application Changes
+
+- Fix ordering of locations due to a bug found in `wwdtm` version 2.10.1
+- Change ordering of locations for `/locations/all` to respect the value of `settings.sort_by_venue` in `config.json`
+- Fix issue where "N/A" is not shown when a location does not have any recordings
+
+### Component Changes
+
+- Upgrade wwdtm from 2.10.1 to 2.11.0
+
+### Development Changes
+
+- Upgrade ruff from 0.5.1 to 0.6.7
+
 ## 6.0.1-post0
 
 ### Application Changes

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -47,7 +47,7 @@ def index() -> Response | str:
     database_connection = mysql.connector.connect(**current_app.config["database"])
     location = Location(database_connection=database_connection)
     location_list = location.retrieve_all(
-        current_app.config["app_settings"]["sort_by_venue"]
+        sort_by_venue=current_app.config["app_settings"]["sort_by_venue"]
     )
     database_connection.close()
 
@@ -99,7 +99,9 @@ def _all() -> Response | str:
     """View: Location Details for All Locations."""
     database_connection = mysql.connector.connect(**current_app.config["database"])
     location = Location(database_connection=database_connection)
-    locations = location.retrieve_all_details()
+    locations = location.retrieve_all_details(
+        sort_by_venue=current_app.config["app_settings"]["sort_by_venue"]
+    )
     database_connection.close()
 
     if not locations:

--- a/app/locations/templates/locations/details.html
+++ b/app/locations/templates/locations/details.html
@@ -76,7 +76,7 @@
         <div class="row">
             <div class="col-md-12 recordings">
                 <span class="field-label">List of Recordings</span>
-                {% if location.recordings %}
+                {% if location.recordings.shows %}
                 <ul class="recording-list {{- ' list-col-2' if location.recordings.shows | length < 6 -}}">
                 {% for show in location.recordings.shows %}
                     {% set show_date = date_string_to_date(date_string=show.date) %}

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "6.0.1"
+APP_VERSION = "6.0.2"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ruff==0.5.1
+ruff==0.6.7
 black==24.4.2
 pytest==8.1.2
 
@@ -6,4 +6,4 @@ Flask==3.0.3
 gunicorn==23.0.0
 Markdown==3.5.2
 
-wwdtm==2.10.1
+wwdtm==2.11.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==3.0.3
 gunicorn==23.0.0
 Markdown==3.5.2
 
-wwdtm==2.10.1
+wwdtm==2.11.0


### PR DESCRIPTION
## Application Changes

- Fix ordering of locations due to a bug found in `wwdtm` version 2.10.1
- Change ordering of locations for `/locations/all` to respect the value of `settings.sort_by_venue` in `config.json`
- Fix issue where "N/A" is not shown when a location does not have any recordings

## Component Changes

- Upgrade wwdtm from 2.10.1 to 2.11.0

## Development Changes

- Upgrade ruff from 0.5.1 to 0.6.7