### PR TITLE
Rename "Best Of Repeats" to "Repeat Best Ofs"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes
 
-## 6.3.0
+## 6.2.1
 
 ### Application Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 6.3.0
+
+### Application Changes
+
+- Rename "Best Of Repeats" to "Repeat Best Ofs" pages and routes
+- Add a redirect for `/shows/best-of-repeats` to point to `/shows/repeat-best-ofs`
+
+### Component Changes
+
+- Upgrade wwdtm from 2.13.0 to 2.14.0
+
 ## 6.2.0
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 
 - Upgrade wwdtm from 2.13.0 to 2.14.0
 
+### Development Changes
+
+- Add missing tests for Best Of, Repeat Best Of and Repeat Shows pages
+
 ## 6.2.0
 
 ### Application Changes

--- a/app/main/redirects.py
+++ b/app/main/redirects.py
@@ -81,6 +81,12 @@ def shows() -> Response:
     return redirect_url(url_for("shows.index"))
 
 
+@blueprint.route("/shows/best-of-repeats")
+def shows_best_of_repeats() -> Response:
+    """Redirect: /shows/best-of-repeats to /shows/repeat-best-ofs."""
+    return redirect_url(url_for("shows.repeat_best_ofs"))
+
+
 @blueprint.route("/s/<string:show_date>")
 def npr_show_redirect(show_date: str) -> Response:
     """Redirects users to the appropriate show page on NPR.org."""

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -71,24 +71,6 @@ def best_ofs() -> Response:
     )
 
 
-@blueprint.route("/best-of-repeats")
-def best_of_repeats() -> Response:
-    """View: Show Details for all Best Of Repeat shows."""
-    database_connection = mysql.connector.connect(**current_app.config["database"])
-    show = Show(database_connection=database_connection)
-    _shows = show.retrieve_all_best_of_repeats_details(
-        include_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"]
-    )
-    if not _shows:
-        return redirect_url(url_for("main.index"))
-
-    return render_template(
-        "shows/best_of_repeats.html",
-        shows=_shows,
-        format_location_name=format_location_name,
-    )
-
-
 @blueprint.route("/<string:iso_date_string>")
 def date_string(iso_date_string: str) -> Response:
     """View: Show Details for a given ISO Date String."""
@@ -307,6 +289,24 @@ def random() -> Response:
 def recent() -> Response:
     """Redirect: /shows/recent to /."""
     return redirect_url(url_for("main.index"))
+
+
+@blueprint.route("/repeat-best-ofs")
+def repeat_best_ofs() -> Response:
+    """View: Show Details for all Repeat Best Of shows."""
+    database_connection = mysql.connector.connect(**current_app.config["database"])
+    show = Show(database_connection=database_connection)
+    _shows = show.retrieve_all_repeat_best_ofs_details(
+        include_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"]
+    )
+    if not _shows:
+        return redirect_url(url_for("main.index"))
+
+    return render_template(
+        "shows/repeat_best_ofs.html",
+        shows=_shows,
+        format_location_name=format_location_name,
+    )
 
 
 @blueprint.route("/repeats")

--- a/app/shows/templates/shows/index.html
+++ b/app/shows/templates/shows/index.html
@@ -22,8 +22,8 @@
                 </a>
             </li>
             <li class="list-group-item">
-                <a href="{{ url_for('shows.best_of_repeats') }}">
-                    <i class="bi-star" aria-hidden="true"></i><i class="bi-repeat" aria-hidden="true"></i>Best Of Repeat Shows
+                <a href="{{ url_for('shows.repeat_best_ofs') }}">
+                    <i class="bi-star" aria-hidden="true"></i><i class="bi-repeat" aria-hidden="true"></i>Repeat Best Of Shows
                 </a>
             </li>
             <li class="list-group-item">

--- a/app/shows/templates/shows/repeat_best_ofs.html
+++ b/app/shows/templates/shows/repeat_best_ofs.html
@@ -1,15 +1,15 @@
 {% extends "base.html" %}
-{% block title %}Best Of Repeats | Shows{% endblock %}
+{% block title %}Repeat Best Ofs | Shows{% endblock %}
 
 {% block content %}
 <nav aria-label="breadcrumb" id="nav-breadcrumb">
     <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{{ url_for('shows.index') }}">Shows</a></li>
-        <li class="breadcrumb-item active" aria-current="page">Best Of Repeats</li>
+        <li class="breadcrumb-item active" aria-current="page">Repeat Best Ofs</li>
     </ol>
 </nav>
 
-<h2>Show Details: Best Of Repeats</h2>
+<h2>Show Details: Repeat Best Ofs</h2>
 
 {% include "shows/details.html" %}
 {% endblock %}

--- a/app/templates/sitemaps/shows.xml
+++ b/app/templates/sitemaps/shows.xml
@@ -26,7 +26,7 @@
     <changefreq>daily</changefreq>
   </url>
   <url>
-    <loc>{{ site_url }}{{ url_for("shows.best_of_repeats")}}</loc>
+    <loc>{{ site_url }}{{ url_for("shows.repeat_best_ofs")}}</loc>
     <changefreq>daily</changefreq>
   </url>
   <url>

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,4 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "6.2.0"
+APP_VERSION = "6.2.1"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ Flask==3.0.3
 gunicorn==23.0.0
 Markdown==3.5.2
 
-wwdtm==2.13.0
+wwdtm==2.14.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==3.0.3
 gunicorn==23.0.0
 Markdown==3.5.2
 
-wwdtm==2.13.0
+wwdtm==2.14.0

--- a/tests/test_main_redirects.py
+++ b/tests/test_main_redirects.py
@@ -105,6 +105,13 @@ def test_shows(client: FlaskClient) -> None:
     assert response.location
 
 
+def test_shows_best_of_repeats(client: FlaskClient) -> None:
+    """Testing main_redirects.shows_best_of_repeats."""
+    response: TestResponse = client.get("/shows/best-of-repeats")
+    assert response.status_code == 302
+    assert response.location
+
+
 @pytest.mark.parametrize("show_date", ["2018-10-27"])
 def test_npr_show_redirect(client: FlaskClient, show_date: str) -> None:
     """Testing main_redirects.guest."""

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -78,6 +78,16 @@ def test_all(client: FlaskClient) -> None:
     assert b"Scorekeeper" in response.data
 
 
+def test_best_ofs(client: FlaskClient) -> None:
+    """Testing shows.best_ofs."""
+    response: TestResponse = client.get("/shows/best-ofs")
+    assert response.status_code == 200
+    assert b"Show Details: Best Ofs" in response.data
+    assert b"Location" in response.data
+    assert b"Host" in response.data
+    assert b"Scorekeeper" in response.data
+
+
 def test_on_this_day(client: FlaskClient) -> None:
     """Testing shows.on_this_day."""
     response: TestResponse = client.get("/shows/on-this-day")
@@ -101,3 +111,23 @@ def test_recent(client: FlaskClient) -> None:
     response: TestResponse = client.get("/shows/recent")
     assert response.status_code == 302
     assert response.location
+
+
+def test_repeat_best_ofs(client: FlaskClient) -> None:
+    """Testing shows.repeat_best_ofs."""
+    response: TestResponse = client.get("/shows/repeat-best-ofs")
+    assert response.status_code == 200
+    assert b"Show Details: Repeat Best Ofs" in response.data
+    assert b"Location" in response.data
+    assert b"Host" in response.data
+    assert b"Scorekeeper" in response.data
+
+
+def test_repeats(client: FlaskClient) -> None:
+    """Testing shows.repeats."""
+    response: TestResponse = client.get("/shows/repeats")
+    assert response.status_code == 200
+    assert b"Show Details: Repeats" in response.data
+    assert b"Location" in response.data
+    assert b"Host" in response.data
+    assert b"Scorekeeper" in response.data


### PR DESCRIPTION
## Application Changes

- Rename "Best Of Repeats" to "Repeat Best Ofs" pages and routes
- Add a redirect for `/shows/best-of-repeats` to point to `/shows/repeat-best-ofs`

## Component Changes

- Upgrade wwdtm from 2.13.0 to 2.14.0

## Development Changes

- Add missing tests for Best Of, Repeat Best Of and Repeat Shows pages