### PR TITLE
Fix issues with incorrect parameter names in redirects for `shows.year_month` and `shows.year_month_day`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 6.2.5
+
+### Application Changes
+
+- Fix issues with incorrect parameter names in redirects for `shows.year_month` and `shows.year_month_day` which cause errors
+- Update copyright dates from 2024 to 2025
+
 ## 6.2.4-post.1
 
 ### Component Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/config.py
+++ b/app/config.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/dicts.py
+++ b/app/dicts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/errors/__init__.py
+++ b/app/errors/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/guests/__init__.py
+++ b/app/guests/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/guests/routes.py
+++ b/app/guests/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/hosts/__init__.py
+++ b/app/hosts/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/hosts/routes.py
+++ b/app/hosts/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/locations/__init__.py
+++ b/app/locations/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/locations/utility.py
+++ b/app/locations/utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/main/__init__.py
+++ b/app/main/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/main/redirects.py
+++ b/app/main/redirects.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/panelists/__init__.py
+++ b/app/panelists/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/scorekeepers/__init__.py
+++ b/app/scorekeepers/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/scorekeepers/routes.py
+++ b/app/scorekeepers/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/shows/__init__.py
+++ b/app/shows/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -146,7 +146,7 @@ def year_month(show_year: int, show_month: int) -> Response | str:
         database_connection.close()
 
         if not shows:
-            return redirect_url(url_for("shows.year", year=show_year))
+            return redirect_url(url_for("shows.year", show_year=show_year))
 
         return render_template(
             "shows/year_month.html",
@@ -155,7 +155,7 @@ def year_month(show_year: int, show_month: int) -> Response | str:
             format_location_name=format_location_name,
         )
     except ValueError:
-        return redirect_url(url_for("shows.year", year=show_year))
+        return redirect_url(url_for("shows.year", show_year=show_year))
 
 
 @blueprint.route("/<int:show_year>/<int:show_month>/<int:show_day>")
@@ -178,7 +178,7 @@ def year_month_day(show_year: int, show_month: int, show_day: int) -> Response |
 
         if not details:
             return redirect_url(
-                url_for("shows.year_month", year=show_year, month=show_month)
+                url_for("shows.year_month", show_year=show_year, show_month=show_month)
             )
 
         show_list = []

--- a/app/sitemaps/__init__.py
+++ b/app/sitemaps/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/sitemaps/routes.py
+++ b/app/sitemaps/routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/utility.py
+++ b/app/utility.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/app/version.py
+++ b/app/version.py
@@ -1,7 +1,7 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "6.2.4-post.1"
+APP_VERSION = "6.2.5"

--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/gunicorn.conf.py.dist
+++ b/gunicorn.conf.py.dist
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/stats.py
+++ b/stats.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_guests.py
+++ b/tests/test_guests.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_main_redirects.py
+++ b/tests/test_main_redirects.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/tests/test_sitemaps.py
+++ b/tests/test_sitemaps.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2024 Linh Pham
+# Copyright (c) 2018-2025 Linh Pham
 # stats.wwdt.me is released under the terms of the Apache License 2.0
 # SPDX-License-Identifier: Apache-2.0
 #


### PR DESCRIPTION
## Application Changes

- Fix issues with incorrect parameter names in redirects for `shows.year_month` and `shows.year_month_day` which cause errors
- Update copyright dates from 2024 to 2025