### PR TITLE
Correct DB ID/pronouns badge ordering for hosts and panelists, Bump ruff version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changes
 
+## 6.3.1
+
+### Application Changes
+
+- Change the ordering of database ID and pronoun badges for hosts and panelists to match the correct ordering used for scorekeepers
+
+### Development Changes
+
+- Upgrade ruff from 0.7.4 to 0.9.2
+
 ## 6.3.0
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Core Application for Wait Wait Stats Page."""
+
 from flask import Flask
 from wwdtm import VERSION as WWDTM_VERSION
 

--- a/app/config.py
+++ b/app/config.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Configuration Loading and Parsing for Wait Wait Stats Page."""
+
 import json
 from pathlib import Path
 from typing import Any

--- a/app/dicts.py
+++ b/app/dicts.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Dictionary objects used by the Wait Wait Stats Page."""
+
 import mysql.connector
 
 PANELIST_RANKS: dict[str, str] = {

--- a/app/errors/handlers.py
+++ b/app/errors/handlers.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Error Handlers Module for Wait Wait Stats Page."""
+
 from typing import Literal
 
 from flask import render_template

--- a/app/guests/routes.py
+++ b/app/guests/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Guests Routes for Wait Wait Stats Page."""
+
 import mysql.connector
 from flask import Blueprint, Response, current_app, redirect, render_template, url_for
 from slugify import slugify

--- a/app/hosts/routes.py
+++ b/app/hosts/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Hosts Routes for Wait Wait Stats Page."""
+
 import mysql.connector
 from flask import Blueprint, Response, current_app, redirect, render_template, url_for
 from slugify import slugify

--- a/app/hosts/templates/hosts/details.html
+++ b/app/hosts/templates/hosts/details.html
@@ -9,10 +9,10 @@
 
     <div class="details">
         <div class="badges">
+            <span class="badge db-id">DB ID: {{ host.id }}</span>
             {% if host.pronouns %}
             <span class="badge pronouns">Pronouns: {{ host.pronouns|join("/")}}</span>
             {% endif %}
-            <span class="badge db-id">DB ID: {{ host.id }}</span>
         </div>
 
         <div class="row">

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Locations Routes for Wait Wait Stats Page."""
+
 import mysql.connector
 from flask import Blueprint, Response, current_app, render_template, url_for
 from slugify import slugify

--- a/app/locations/utility.py
+++ b/app/locations/utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Location name formatting functions used by the Stats Page."""
+
 from decimal import Decimal
 from math import copysign, floor
 

--- a/app/main/redirects.py
+++ b/app/main/redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Main Redirect Routes for Wait Wait Stats Page."""
+
 from datetime import datetime
 
 import mysql.connector

--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Main Routes for Wait Wait Stats Page."""
+
 from pathlib import Path
 
 import mysql.connector

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Panelists Routes for Wait Wait Stats Page."""
+
 import mysql.connector
 from flask import Blueprint, Response, current_app, redirect, render_template, url_for
 from slugify import slugify

--- a/app/panelists/templates/panelists/details.html
+++ b/app/panelists/templates/panelists/details.html
@@ -5,10 +5,10 @@
     <h3 class="name"><a href="{{ url_for('panelists.details', panelist_slug=panelist.slug) }}">{{ panelist.name }}</a></h3>
     <div class="details">
         <div class="badges">
+            <span class="badge db-id">DB ID: {{ panelist.id }}</span>
             {% if panelist.pronouns %}
             <span class="badge pronouns">Pronouns: {{ panelist.pronouns|join("/")}}</span>
             {% endif %}
-            <span class="badge db-id">DB ID: {{ panelist.id }}</span>
         </div>
 
         <div class="row">

--- a/app/scorekeepers/routes.py
+++ b/app/scorekeepers/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Scorekeepers Routes for Wait Wait Stats Page."""
+
 import mysql.connector
 from flask import Blueprint, Response, current_app, redirect, render_template, url_for
 from slugify import slugify

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Shows Routes for Wait Wait Stats Page."""
+
 import datetime
 from datetime import date
 from typing import Any

--- a/app/sitemaps/routes.py
+++ b/app/sitemaps/routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Sitemap Routes for Wait Wait Stats Page."""
+
 import mysql.connector
 from flask import Blueprint, Response, current_app, render_template
 from wwdtm.guest import Guest

--- a/app/utility.py
+++ b/app/utility.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Utility functions used by the Wait Wait Stats Page."""
+
 import json
 from datetime import datetime
 

--- a/app/version.py
+++ b/app/version.py
@@ -4,4 +4,5 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
-APP_VERSION = "6.3.0"
+
+APP_VERSION = "6.3.1"

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """pytest conftest.py File."""
+
 import pytest
 
 from app import create_app

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ruff==0.7.4
+ruff==0.9.2
 black==24.10.0
 pytest==8.3.3
 pytest-cov==5.0.0

--- a/stats.py
+++ b/stats.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Bootstrap Script for Wait Wait Stats Page."""
+
 from app import create_app
 
 app = create_app()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Errors Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_guests.py
+++ b/tests/test_guests.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Guests Module and Blueprint Views."""
+
 import pytest
 from flask.testing import FlaskClient
 from slugify import slugify

--- a/tests/test_hosts.py
+++ b/tests/test_hosts.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Hosts Module and Blueprint Views."""
+
 import pytest
 from flask.testing import FlaskClient
 from slugify import slugify

--- a/tests/test_locations.py
+++ b/tests/test_locations.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Locations Module and Blueprint Views."""
+
 import pytest
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse

--- a/tests/test_main_redirects.py
+++ b/tests/test_main_redirects.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Main Redirects Module and Blueprint Views."""
+
 import pytest
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse

--- a/tests/test_main_routes.py
+++ b/tests/test_main_routes.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Main Routes Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 

--- a/tests/test_panelists.py
+++ b/tests/test_panelists.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Panelists Module and Blueprint Views."""
+
 import pytest
 from flask.testing import FlaskClient
 from slugify import slugify

--- a/tests/test_scorekeepers.py
+++ b/tests/test_scorekeepers.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Scorekeepers Module and Blueprint Views."""
+
 import pytest
 from flask.testing import FlaskClient
 from slugify import slugify

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Shows Module and Blueprint Views."""
+
 import pytest
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse

--- a/tests/test_sitemaps.py
+++ b/tests/test_sitemaps.py
@@ -4,6 +4,7 @@
 #
 # vim: set noai syntax=python ts=4 sw=4:
 """Testing Sitemaps Module and Blueprint Views."""
+
 from flask.testing import FlaskClient
 from werkzeug.test import TestResponse
 


### PR DESCRIPTION
## Application Changes

- Change the ordering of database ID and pronoun badges for hosts and panelists to match the correct ordering used for scorekeepers

## Development Changes

- Upgrade ruff from 0.7.4 to 0.9.2