### PR TITLE
Bump wwdtm to fix locations w/o state, Fully replace black with ruff

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,5 @@
             "source.fixAll": "explicit",
             "source.sortImports": "explicit",
         },
-        "editor.defaultFormatter": "ms-python.black-formatter"
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changes
 
+## 6.4.1
+
+### Application Changes
+
+- Fix an issue where "Home/Remote Studios" location was not appearing in the Locations page due to an issue that was found in the `wwdtm` library.
+
+### Component Changes
+
+- Update wwdtm from 2.14.0 to 2.15.0
+
+### Development Changes
+
+- Upgrade ruff from 0.9.2 to 0.9.3
+- Remove black from required development packages as part of migrating entirely to Ruff
+
 ## 6.4.0
 
 ### Application Changes

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Flask-based web application that serves up statistics and details for the NPR we
 
 ## Requirements
 
-- Python 3.10 or newer
+- Python 3.10 through 3.12 (Python 3.13 has not been tested)
 - MySQL Server 8.0 or newer, or another MySQL Server distribution based on MySQL Server 8.0 or newer, hosting a version of the aforementioned Wait Wait Don't Tell Me! Stats database
 
 ## Installation
@@ -25,7 +25,7 @@ If you would like contribute to this project, please make sure to review both th
 
 ## Sponsoring
 
-If you would like to help sponsor the continued development and maintenance of the Wait Wait Stats project, please consider sponsoring me on [GitHub](https://github.com/sponsors/questionlp) or on [Patreon](https://patreon.com/Linh_Pham).
+If you would like to help sponsor the continued development and maintenance of the Wait Wait Stats project, please consider sponsoring me on [GitHub](https://github.com/sponsors/questionlp).
 
 ## License and Acknowledgements
 

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.4.0"
+APP_VERSION = "6.4.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
-[tool.black]
-required-version = "24.10.0"
-target-version = ["py310", "py311", "py312", "py313"]
-line-length = 88
-
 [tool.pytest.ini_options]
 minversion = "8.3"
 filterwarnings = [
@@ -17,6 +12,7 @@ norecursedirs = [
 ]
 
 [tool.ruff]
+required-version = ">= 0.9.0"
 target-version = "py310"
 
 exclude = [
@@ -30,7 +26,7 @@ exclude = [
     ".venv",
 ]
 
-line-length = 88 # Must agree with Black
+line-length = 88
 
 [tool.ruff.lint]
 ignore = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
-ruff==0.9.2
-black==24.10.0
+ruff==0.9.3
 pytest==8.3.3
 pytest-cov==5.0.0
 
@@ -7,4 +6,4 @@ Flask==3.1.0
 gunicorn==23.0.0
 Markdown==3.7.0
 
-wwdtm==2.14.0
+wwdtm==2.15.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==3.1.0
 gunicorn==23.0.0
 Markdown==3.7.0
 
-wwdtm==2.14.0
+wwdtm==2.15.0


### PR DESCRIPTION
## Application Changes

- Fix an issue where "Home/Remote Studios" location was not appearing in the Locations page due to an issue that was found in the `wwdtm` library.

## Component Changes

- Update wwdtm from 2.14.0 to 2.15.0

## Development Changes

- Upgrade ruff from 0.9.2 to 0.9.3
- Remove black from required development packages as part of migrating entirely to Ruff