### PR TITLE
Migrate random routes to use wwdtm methods, add random show by year

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 6.5.0
+
+### Application Changes
+
+- Migrate random guest, host, location, panelist, scorekeeper and show routes to use the new corresponding methods in the `wwdtm` library.
+- Add the ability to get a random show for a given year
+
+### Component Updates
+
+- Upgrade wwdtm from 2.15.0 to 2.17.0
+
 ## 6.4.1
 
 ### Application Changes
@@ -8,7 +19,7 @@
 
 ### Component Changes
 
-- Update wwdtm from 2.14.0 to 2.15.0
+- Upgrade wwdtm from 2.14.0 to 2.15.0
 
 ### Development Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Migrate random guest, host, location, panelist, scorekeeper and show routes to use the new corresponding methods in the `wwdtm` library.
 - Add the ability to get a random show for a given year
+- Add additional exception handling for show routes that have URL parts expecting integer values
+- Clean up database connections within `try/except/finally` blocks
 
 ### Component Updates
 

--- a/app/guests/routes.py
+++ b/app/guests/routes.py
@@ -51,6 +51,7 @@ def details(guest_slug: str) -> Response | str:
 
     guests = []
     guests.append(_details)
+
     return render_template(
         "guests/single.html", guest_name=_details["name"], guests=guests
     )
@@ -76,4 +77,6 @@ def random() -> Response:
     database_connection = mysql.connector.connect(**current_app.config["database"])
     guest = Guest(database_connection=database_connection)
     _slug = guest.retrieve_random_slug()
+    database_connection.close()
+
     return redirect_url(url_for("guests.details", guest_slug=_slug))

--- a/app/guests/routes.py
+++ b/app/guests/routes.py
@@ -15,27 +15,6 @@ from app.utility import redirect_url
 blueprint = Blueprint("guests", __name__, template_folder="templates")
 
 
-def random_guest_slug() -> str | None:
-    """Return a random guest slug from ww_guests table."""
-    database_connection = mysql.connector.connect(**current_app.config["database"])
-    cursor = database_connection.cursor(dictionary=False)
-    query = (
-        "SELECT g.guestslug FROM ww_guests g "
-        "WHERE g.guestslug <> 'none' "
-        "ORDER BY RAND() "
-        "LIMIT 1;"
-    )
-    cursor.execute(query)
-    result = cursor.fetchone()
-    cursor.close()
-    database_connection.close()
-
-    if not result:
-        return None
-
-    return str(result[0])
-
-
 @blueprint.route("/")
 def index() -> Response | str:
     """View: Guests Index."""
@@ -94,5 +73,7 @@ def _all() -> Response | str:
 @blueprint.route("/random")
 def random() -> Response:
     """View: Random Guest Redirect."""
-    _slug = random_guest_slug()
+    database_connection = mysql.connector.connect(**current_app.config["database"])
+    guest = Guest(database_connection=database_connection)
+    _slug = guest.retrieve_random_slug()
     return redirect_url(url_for("guests.details", guest_slug=_slug))

--- a/app/hosts/routes.py
+++ b/app/hosts/routes.py
@@ -51,6 +51,7 @@ def details(host_slug: str) -> Response | str:
 
     hosts = []
     hosts.append(_details)
+
     return render_template("hosts/single.html", host_name=_details["name"], hosts=hosts)
 
 
@@ -74,4 +75,6 @@ def random() -> Response:
     database_connection = mysql.connector.connect(**current_app.config["database"])
     host = Host(database_connection=database_connection)
     _slug = host.retrieve_random_slug()
+    database_connection.close()
+
     return redirect_url(url_for("hosts.details", host_slug=_slug))

--- a/app/hosts/routes.py
+++ b/app/hosts/routes.py
@@ -15,27 +15,6 @@ from app.utility import redirect_url
 blueprint = Blueprint("hosts", __name__, template_folder="templates")
 
 
-def random_host_slug() -> str | None:
-    """Return a random host slug from ww_hosts table."""
-    database_connection = mysql.connector.connect(**current_app.config["database"])
-    cursor = database_connection.cursor(dictionary=False)
-    query = (
-        "SELECT h.hostslug FROM ww_hosts h "
-        "WHERE h.hostslug <> 'tbd' "
-        "ORDER BY RAND() "
-        "LIMIT 1;"
-    )
-    cursor.execute(query)
-    result = cursor.fetchone()
-    cursor.close()
-    database_connection.close()
-
-    if not result:
-        return None
-
-    return str(result[0])
-
-
 @blueprint.route("/")
 def index() -> Response | str:
     """View: Hosts Index."""
@@ -92,5 +71,7 @@ def _all() -> Response | str:
 @blueprint.route("/random")
 def random() -> Response:
     """View: Random Host Redirect."""
-    _slug = random_host_slug()
+    database_connection = mysql.connector.connect(**current_app.config["database"])
+    host = Host(database_connection=database_connection)
+    _slug = host.retrieve_random_slug()
     return redirect_url(url_for("hosts.details", host_slug=_slug))

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -21,27 +21,6 @@ from app.utility import redirect_url
 blueprint = Blueprint("locations", __name__, template_folder="templates")
 
 
-def random_location_slug() -> str | None:
-    """Return a random location slug from ww_locations table."""
-    database_connection = mysql.connector.connect(**current_app.config["database"])
-    cursor = database_connection.cursor(dictionary=False)
-    query = (
-        "SELECT l.locationslug FROM ww_locations l "
-        "WHERE l.locationslug <> 'tbd' "
-        "ORDER BY RAND() "
-        "LIMIT 1;"
-    )
-    cursor.execute(query)
-    result = cursor.fetchone()
-    cursor.close()
-    database_connection.close()
-
-    if not result:
-        return None
-
-    return str(result[0])
-
-
 @blueprint.route("/")
 def index() -> Response | str:
     """View: Locations Index."""
@@ -122,5 +101,7 @@ def _all() -> Response | str:
 @blueprint.route("/random")
 def random() -> Response:
     """View: Random Location Redirect."""
-    _slug = random_location_slug()
+    database_connection = mysql.connector.connect(**current_app.config["database"])
+    location = Location(database_connection=database_connection)
+    _slug = location.retrieve_random_slug()
     return redirect_url(url_for("locations.details", location_slug=_slug))

--- a/app/locations/routes.py
+++ b/app/locations/routes.py
@@ -63,6 +63,7 @@ def details(location_slug: str) -> Response | str:
     # Template expects a list of location(s)
     locations = []
     locations.append(_details)
+
     return render_template(
         "locations/single.html",
         locations=locations,
@@ -104,4 +105,6 @@ def random() -> Response:
     database_connection = mysql.connector.connect(**current_app.config["database"])
     location = Location(database_connection=database_connection)
     _slug = location.retrieve_random_slug()
+    database_connection.close()
+
     return redirect_url(url_for("locations.details", location_slug=_slug))

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -15,27 +15,6 @@ from app.utility import redirect_url
 blueprint = Blueprint("panelists", __name__, template_folder="templates")
 
 
-def random_panelist_slug() -> str | None:
-    """Return a random panelist slug from ww_panelists table."""
-    database_connection = mysql.connector.connect(**current_app.config["database"])
-    cursor = database_connection.cursor(dictionary=False)
-    query = (
-        "SELECT p.panelistslug FROM ww_panelists p "
-        "WHERE p.panelistslug <> 'multiple' "
-        "ORDER BY RAND() "
-        "LIMIT 1;"
-    )
-    cursor.execute(query)
-    result = cursor.fetchone()
-    cursor.close()
-    database_connection.close()
-
-    if not result:
-        return None
-
-    return str(result[0])
-
-
 @blueprint.route("/")
 def index() -> Response | str:
     """View: Panelists Index."""
@@ -99,5 +78,7 @@ def _all() -> Response | str:
 @blueprint.route("/random")
 def random() -> Response:
     """View: Random Panelist Redirect."""
-    _slug = random_panelist_slug()
+    database_connection = mysql.connector.connect(**current_app.config["database"])
+    panelist = Panelist(database_connection=database_connection)
+    _slug = panelist.retrieve_random_slug()
     return redirect_url(url_for("panelists.details", panelist_slug=_slug))

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -54,6 +54,7 @@ def details(panelist_slug: str) -> Response | str:
 
     panelists = []
     panelists.append(_details)
+
     return render_template(
         "panelists/single.html", panelist_name=_details["name"], panelists=panelists
     )
@@ -81,4 +82,6 @@ def random() -> Response:
     database_connection = mysql.connector.connect(**current_app.config["database"])
     panelist = Panelist(database_connection=database_connection)
     _slug = panelist.retrieve_random_slug()
+    database_connection.close()
+
     return redirect_url(url_for("panelists.details", panelist_slug=_slug))

--- a/app/scorekeepers/routes.py
+++ b/app/scorekeepers/routes.py
@@ -51,6 +51,7 @@ def details(scorekeeper_slug: str) -> Response | str:
 
     scorekeepers = []
     scorekeepers.append(_details)
+
     return render_template(
         "scorekeepers/single.html",
         scorekeeper_name=_details["name"],
@@ -78,4 +79,6 @@ def random() -> Response:
     database_connection = mysql.connector.connect(**current_app.config["database"])
     scorekeeper = Scorekeeper(database_connection=database_connection)
     _slug = scorekeeper.retrieve_random_slug()
+    database_connection.close()
+
     return redirect_url(url_for("scorekeepers.details", scorekeeper_slug=_slug))

--- a/app/scorekeepers/routes.py
+++ b/app/scorekeepers/routes.py
@@ -15,27 +15,6 @@ from app.utility import redirect_url
 blueprint = Blueprint("scorekeepers", __name__, template_folder="templates")
 
 
-def random_scorekeeper_slug() -> str | None:
-    """Return a random scorekeeper slug from ww_scorekeepers table."""
-    database_connection = mysql.connector.connect(**current_app.config["database"])
-    cursor = database_connection.cursor(dictionary=False)
-    query = (
-        "SELECT sk.scorekeeperslug FROM ww_scorekeepers sk "
-        "WHERE sk.scorekeeperslug <> 'tbd' "
-        "ORDER BY RAND() "
-        "LIMIT 1;"
-    )
-    cursor.execute(query)
-    result = cursor.fetchone()
-    cursor.close()
-    database_connection.close()
-
-    if not result:
-        return None
-
-    return str(result[0])
-
-
 @blueprint.route("/")
 def index() -> Response | str:
     """View: Scorekeepers Index."""
@@ -96,5 +75,7 @@ def _all() -> Response | str:
 @blueprint.route("/random")
 def random() -> Response:
     """View: Random Scorekeeper Redirect."""
-    _slug = random_scorekeeper_slug()
+    database_connection = mysql.connector.connect(**current_app.config["database"])
+    scorekeeper = Scorekeeper(database_connection=database_connection)
+    _slug = scorekeeper.retrieve_random_slug()
     return redirect_url(url_for("scorekeepers.details", scorekeeper_slug=_slug))

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -41,6 +41,7 @@ def best_ofs() -> Response:
     _best_ofs = show.retrieve_all_best_ofs_details(
         include_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"]
     )
+    database_connection.close()
     if not _best_ofs:
         return redirect_url(url_for("main.index"))
 
@@ -78,6 +79,8 @@ def date_string(iso_date_string: str) -> Response:
         return redirect_url(url_for("shows.index"))
     except TypeError:
         return redirect_url(url_for("shows.index"))
+    finally:
+        database_connection.close()
 
 
 @blueprint.route("/<int:show_year>")
@@ -90,7 +93,6 @@ def year(show_year: str | int) -> Response | str:
         _year = int(show_year)
         date_year = date(year=_year, month=1, day=1)
         show_months = show.retrieve_months_by_year(year=_year)
-        database_connection.close()
 
         if not show_months:
             return redirect_url(url_for("shows.index"))
@@ -106,6 +108,8 @@ def year(show_year: str | int) -> Response | str:
         return redirect_url(url_for("shows.index"))
     except OverflowError:
         return redirect_url(url_for("shows.index"))
+    finally:
+        database_connection.close()
 
 
 @blueprint.route("/<int:show_year>/<int:show_month>")
@@ -123,7 +127,6 @@ def year_month(show_year: int, show_month: int) -> Response | str:
                 "use_decimal_scores"
             ],
         )
-        database_connection.close()
 
         if not shows:
             return redirect_url(url_for("shows.year", show_year=show_year))
@@ -136,6 +139,12 @@ def year_month(show_year: int, show_month: int) -> Response | str:
         )
     except ValueError:
         return redirect_url(url_for("shows.year", show_year=show_year))
+    except TypeError:
+        return redirect_url(url_for("shows.index"))
+    except OverflowError:
+        return redirect_url(url_for("shows.index"))
+    finally:
+        database_connection.close()
 
 
 @blueprint.route("/<int:show_year>/<int:show_month>/<int:show_day>")
@@ -154,7 +163,6 @@ def year_month_day(show_year: int, show_month: int, show_day: int) -> Response |
                 "use_decimal_scores"
             ],
         )
-        database_connection.close()
 
         if not details:
             return redirect_url(
@@ -170,8 +178,13 @@ def year_month_day(show_year: int, show_month: int, show_day: int) -> Response |
             format_location_name=format_location_name,
         )
     except ValueError:
-        database_connection.close()
         return redirect_url(url_for("shows.index"))
+    except TypeError:
+        return redirect_url(url_for("shows.index"))
+    except OverflowError:
+        return redirect_url(url_for("shows.index"))
+    finally:
+        database_connection.close()
 
 
 @blueprint.route("/<int:show_year>/all")
@@ -188,7 +201,6 @@ def year_all(show_year: int) -> Response | str | Any:
                 "use_decimal_scores"
             ],
         )
-        database_connection.close()
 
         if not shows:
             return redirect_url(url_for("shows.index"))
@@ -201,6 +213,12 @@ def year_all(show_year: int) -> Response | str | Any:
         )
     except ValueError:
         return redirect_url(url_for("shows.year", show_year=show_year))
+    except TypeError:
+        return redirect_url(url_for("shows.index"))
+    except OverflowError:
+        return redirect_url(url_for("shows.index"))
+    finally:
+        database_connection.close()
 
 
 @blueprint.route("/all")
@@ -225,8 +243,6 @@ def _all() -> Response | str:
             )
             _shows_by_year[_year] = shows
 
-        database_connection.close()
-
         return render_template(
             "shows/all.html",
             show_years=show_years,
@@ -235,6 +251,8 @@ def _all() -> Response | str:
         )
     except ValueError:
         return redirect_url(url_for("shows.index"))
+    finally:
+        database_connection.close()
 
 
 @blueprint.route("/on-this-day")
@@ -264,6 +282,7 @@ def random() -> Response:
     database_connection = mysql.connector.connect(**current_app.config["database"])
     show = Show(database_connection=database_connection)
     _date = show.retrieve_random_date()
+    database_connection.close()
     return redirect_url(url_for("shows.date_string", iso_date_string=_date))
 
 
@@ -274,7 +293,8 @@ def random_year_show(show_year: int) -> Response:
     show = Show(database_connection=database_connection)
 
     try:
-        _ = date(year=show_year, month=1, day=1)
+        _year = int(show_year)
+        _ = date(year=_year, month=1, day=1)
         _date = show.retrieve_random_date_by_year(year=show_year)
 
         if not _date:
@@ -283,6 +303,12 @@ def random_year_show(show_year: int) -> Response:
         return redirect_url(url_for("shows.date_string", iso_date_string=_date))
     except ValueError:
         return redirect_url(url_for("shows.index"))
+    except TypeError:
+        return redirect_url(url_for("shows.index"))
+    except OverflowError:
+        return redirect_url(url_for("shows.index"))
+    finally:
+        database_connection.close()
 
 
 @blueprint.route("/recent")
@@ -299,6 +325,7 @@ def repeat_best_ofs() -> Response:
     _shows = show.retrieve_all_repeat_best_ofs_details(
         include_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"]
     )
+    database_connection.close()
     if not _shows:
         return redirect_url(url_for("main.index"))
 
@@ -317,6 +344,7 @@ def repeats() -> Response:
     _repeats = show.retrieve_all_repeats_details(
         include_decimal_scores=current_app.config["app_settings"]["use_decimal_scores"]
     )
+    database_connection.close()
     if not _repeats:
         return redirect_url(url_for("main.index"))
 

--- a/app/shows/templates/shows/year.html
+++ b/app/shows/templates/shows/year.html
@@ -18,6 +18,11 @@
 <div class="info">
     <div class="shows">
         <ul class="list-group show-list">
+            <li class="list-group-item">
+                <a href="{{ url_for('shows.random_year_show', show_year=year.year) }}">
+                    <i class="bi-shuffle" aria-hidden="true"></i>Random Show from {{ year.year }}
+                </a>
+            </li>
             {% for month in show_months %}
             <li class="list-group-item">
                 <a href="{{ url_for('shows.year_month', show_year=month.year, show_month=month.month) }}">{{ month.strftime("%B %Y") }}</a>

--- a/app/sitemaps/routes.py
+++ b/app/sitemaps/routes.py
@@ -29,6 +29,7 @@ def primary() -> Response | None:
         return None
 
     sitemap = render_template("sitemaps/sitemap.xml", show_years=years)
+
     return Response(sitemap, mimetype="text/xml")
 
 
@@ -44,6 +45,7 @@ def guests() -> Response | None:
         return None
 
     sitemap = render_template("sitemaps/guests.xml", guests=_guests)
+
     return Response(sitemap, mimetype="text/xml")
 
 
@@ -59,6 +61,7 @@ def hosts() -> Response | None:
         return None
 
     sitemap = render_template("sitemaps/hosts.xml", hosts=_hosts)
+
     return Response(sitemap, mimetype="text/xml")
 
 
@@ -74,6 +77,7 @@ def locations() -> Response | None:
         return None
 
     sitemap = render_template("sitemaps/locations.xml", locations=_locations)
+
     return Response(sitemap, mimetype="text/xml")
 
 
@@ -88,6 +92,7 @@ def panelists() -> Response | None:
         return None
 
     sitemap = render_template("sitemaps/panelists.xml", panelists=_panelists)
+
     return Response(sitemap, mimetype="text/xml")
 
 
@@ -103,6 +108,7 @@ def scorekeepers() -> Response | None:
         return None
 
     sitemap = render_template("sitemaps/scorekeepers.xml", scorekeepers=_scorekeepers)
+
     return Response(sitemap, mimetype="text/xml")
 
 
@@ -121,4 +127,5 @@ def shows() -> Response | None:
     sitemap = render_template(
         "sitemaps/shows.xml", show_dates=dates, show_years_months=years_months
     )
+
     return Response(sitemap, mimetype="text/xml")

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.4.1"
+APP_VERSION = "6.5.0"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ Flask==3.1.0
 gunicorn==23.0.0
 Markdown==3.7.0
 
-wwdtm==2.15.0
+wwdtm==2.17.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ Flask==3.1.0
 gunicorn==23.0.0
 Markdown==3.7.0
 
-wwdtm==2.15.0
+wwdtm==2.17.0

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -107,6 +107,14 @@ def test_random(client: FlaskClient) -> None:
     assert response.location
 
 
+@pytest.mark.parametrize("year", [1998, 2020])
+def test_random_year_show(client: FlaskClient, year: int) -> None:
+    """Testing shows.random."""
+    response: TestResponse = client.get(f"/shows/random/{year}")
+    assert response.status_code == 302
+    assert str(year) in response.location
+
+
 def test_recent(client: FlaskClient) -> None:
     """Testing shows.recent."""
     response: TestResponse = client.get("/shows/recent")


### PR DESCRIPTION
## Application Changes

- Migrate random guest, host, location, panelist, scorekeeper and show routes to use the new corresponding methods in the `wwdtm` library.
- Add the ability to get a random show for a given year
- Add additional exception handling for show routes that have URL parts expecting integer values
- Clean up database connections within `try/except/finally` blocks

## Component Updates

- Upgrade wwdtm from 2.15.0 to 2.17.0