### PR TITLE
Update AI bots list in robots.txt and Bump Ruff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changes
 
-## 6.5.2
+## 6.5.3
 
 ### Application Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,23 @@
 
 ## 6.5.2
 
-### Component Updates
+### Application Changes
+
+- Update list of AI bots from <https://github.com/ai-robots-txt/ai.robots.txt> in the default `robots.txt`
+
+### Development Changes
+
+- Upgrade ruff from 0.9.3 to 0.9.6
+
+## 6.5.2
+
+### Component Changes
 
 - Upgrade wwdtm from 2.17.1 to 2.17.2
 
 ## 6.5.1
 
-### Component Updates
+### Component Changes
 
 - Upgrade wwdtm from 2.17.0 to 2.17.1
 
@@ -21,7 +31,7 @@
 - Add additional exception handling for show routes that have URL parts expecting integer values
 - Clean up database connections within `try/except/finally` blocks
 
-### Component Updates
+### Component Changes
 
 - Upgrade wwdtm from 2.15.0 to 2.17.0
 

--- a/app/templates/robots.txt
+++ b/app/templates/robots.txt
@@ -7,7 +7,10 @@ Sitemap: {{ site_url }}{{ url_for("sitemaps.scorekeepers") }}
 Sitemap: {{ site_url }}{{ url_for("sitemaps.shows") }}
 
 {% if block_ai_scrapers %}
+User-agent: AI2Bot
+User-agent: Ai2Bot-Dolma
 User-agent: Amazonbot
+User-agent: anthropic-ai
 User-agent: Applebot
 User-agent: Applebot-Extended
 User-agent: Bytespider
@@ -15,31 +18,40 @@ User-agent: CCBot
 User-agent: ChatGPT-User
 User-agent: Claude-Web
 User-agent: ClaudeBot
+User-agent: cohere-ai
+User-agent: cohere-training-data-crawler
+User-agent: Crawlspace
 User-agent: Diffbot
+User-agent: DuckAssistBot
 User-agent: FacebookBot
 User-agent: FriendlyCrawler
-User-agent: GPTBot
 User-agent: Google-Extended
 User-agent: GoogleOther
 User-agent: GoogleOther-Image
 User-agent: GoogleOther-Video
+User-agent: GPTBot
+User-agent: iaskspider/2.0
 User-agent: ICC-Crawler
 User-agent: ImagesiftBot
+User-agent: img2dataset
+User-agent: ISSCyberRiskCrawler
+User-agent: Kangaroo Bot
 User-agent: Meta-ExternalAgent
 User-agent: Meta-ExternalFetcher
 User-agent: OAI-SearchBot
+User-agent: omgili
+User-agent: omgilibot
+User-agent: PanguBot
 User-agent: PerplexityBot
 User-agent: PetalBot
 User-agent: Scrapy
+User-agent: SemrushBot-OCOB
+User-agent: SemrushBot-SWA
+User-agent: Sidetrade indexer bot
 User-agent: Timpibot
 User-agent: VelenPublicWebCrawler
+User-agent: Webzio-Extended
 User-agent: YouBot
-User-agent: anthropic-ai
-User-agent: cohere-ai
-User-agent: facebookexternalhit
-User-agent: img2dataset
-User-agent: omgili
-User-agent: omgilibot
 Disallow: /
 {% endif %}
 
@@ -50,3 +62,4 @@ Disallow: {{ url_for("panelists._all") }}$
 Disallow: {{ url_for("scorekeepers._all") }}$
 Disallow: {{ url_for("shows._all") }}$
 Disallow: /s/
+Disallow: /teapot

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.5.2"
+APP_VERSION = "6.5.3"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-ruff==0.9.3
+ruff==0.9.6
 pytest==8.3.3
 pytest-cov==5.0.0
 


### PR DESCRIPTION
## Application Changes

- Update list of AI bots from <https://github.com/ai-robots-txt/ai.robots.txt> in the default `robots.txt`

## Development Changes

- Upgrade ruff from 0.9.3 to 0.9.6