### PR TITLE
Relocate Bootstrap and app JS, corrected Umami include in error page …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changes
 
+## 6.5.5
+
+### Application Changes
+
+- Relocate the Bootstrap and application code initialization from towards the end of the document to the head to prevent background flashing on page loads when in dark mode
+- Corrected Umami Analytics include for error page template
+- Update Bootstrap icon classes to include `.bi`
+
+### Component Changes
+
+- Set Jinja2 version to `~=3.1.6`
+
 ## 6.5.4
 
 ### Application Changes

--- a/app/guests/templates/guests/index.html
+++ b/app/guests/templates/guests/index.html
@@ -19,7 +19,7 @@
         <ul class="list-group name-list">
             <li class="list-group-item">
                 <a href="{{ url_for('guests.random') }}">
-                    <i class="bi-shuffle" aria-hidden="true"></i>Random Guest
+                    <i class="bi bi-shuffle" aria-hidden="true"></i>Random Guest
                 </a>
             </li>
             {% for guest in guests %}

--- a/app/hosts/templates/hosts/index.html
+++ b/app/hosts/templates/hosts/index.html
@@ -18,7 +18,7 @@
         <ul class="list-group name-list">
             <li class="list-group-item">
                 <a href="{{ url_for('hosts.random') }}">
-                    <i class="bi-shuffle" aria-hidden="true"></i>Random Host
+                    <i class="bi bi-shuffle" aria-hidden="true"></i>Random Host
                 </a>
             </li>
             {% for host in hosts %}

--- a/app/locations/templates/locations/details.html
+++ b/app/locations/templates/locations/details.html
@@ -37,7 +37,7 @@
                 </span>
                     {% if display_location_map %}
                 <span class="map-link">
-                    <i class="bi-map" aria-hidden="true"></i> <a href="#map-block" title="Scroll down to location map">Location Map</a>
+                    <i class="bi bi-map" aria-hidden="true"></i> <a href="#map-block" title="Scroll down to location map">Location Map</a>
                 </span>
                     {% endif %}
                 {% else %}

--- a/app/locations/templates/locations/index.html
+++ b/app/locations/templates/locations/index.html
@@ -18,7 +18,7 @@
         <ul class="list-group location-list">
             <li class="list-group-item">
                 <a href="{{ url_for('locations.random') }}">
-                    <i class="bi-shuffle" aria-hidden="true"></i>Random Location
+                    <i class="bi bi-shuffle" aria-hidden="true"></i>Random Location
                 </a>
             </li>
             {% for location in locations %}

--- a/app/panelists/templates/panelists/index.html
+++ b/app/panelists/templates/panelists/index.html
@@ -18,7 +18,7 @@
         <ul class="list-group name-list">
             <li class="list-group-item">
                 <a href="{{ url_for('panelists.random') }}">
-                    <i class="bi-shuffle" aria-hidden="true"></i>Random Panelist
+                    <i class="bi bi-shuffle" aria-hidden="true"></i>Random Panelist
                 </a>
             </li>
             {% for panelist in panelists %}

--- a/app/scorekeepers/templates/scorekeepers/index.html
+++ b/app/scorekeepers/templates/scorekeepers/index.html
@@ -19,7 +19,7 @@
         <ul class="list-group name-list">
             <li class="list-group-item">
                 <a href="{{ url_for('scorekeepers.random') }}">
-                    <i class="bi-shuffle" aria-hidden="true"></i>Random Scorekeeper
+                    <i class="bi bi-shuffle" aria-hidden="true"></i>Random Scorekeeper
                 </a>
             </li>
             {% for scorekeeper in scorekeepers %}

--- a/app/shows/templates/shows/all_details.html
+++ b/app/shows/templates/shows/all_details.html
@@ -21,9 +21,9 @@
         {% endif %}
         <span class="badge npr-link">
         {% if show.show_url %}
-            <a href="{{ show.show_url }}">NPR<i class="bi-box-arrow-right" aria-hidden="true"></i></a>
+            <a href="{{ show.show_url }}">NPR<i class="bi bi-box-arrow-right" aria-hidden="true"></i></a>
         {% else %}
-            <a href="{{ url_for('main_redirects.npr_show_redirect', show_date=show.date) }}">NPR<i class="bi-box-arrow-right" aria-hidden="true"></i></a>
+            <a href="{{ url_for('main_redirects.npr_show_redirect', show_date=show.date) }}">NPR<i class="bi bi-box-arrow-right" aria-hidden="true"></i></a>
         {% endif %}
         </span>
         <span class="badge db-id">DB ID: {{ show.id }}</span>
@@ -197,7 +197,7 @@
 {% endfor %}
 
 <div class="my-4">
-    <a href="#year-list"><i class="bi-arrow-up" aria-hidden="true"></i>Return to Year List</a>
+    <a href="#year-list"><i class="bi bi-arrow-up" aria-hidden="true"></i>Return to Year List</a>
 </div>
 
 {% endfor %}

--- a/app/shows/templates/shows/details.html
+++ b/app/shows/templates/shows/details.html
@@ -25,9 +25,9 @@
             {% endif %}
             <span class="badge npr-link">
             {% if show.show_url %}
-                <a href="{{ show.show_url }}">NPR<i class="bi-box-arrow-right" aria-hidden="true"></i></a>
+                <a href="{{ show.show_url }}">NPR<i class="bi bi-box-arrow-right" aria-hidden="true"></i></a>
             {% else %}
-                <a href="{{ url_for('main_redirects.npr_show_redirect', show_date=show.date) }}">NPR<i class="bi-box-arrow-right" aria-hidden="true"></i></a>
+                <a href="{{ url_for('main_redirects.npr_show_redirect', show_date=show.date) }}">NPR<i class="bi bi-box-arrow-right" aria-hidden="true"></i></a>
             {% endif %}
             </span>
             <span class="badge db-id">DB ID: {{ show.id }}</span>

--- a/app/shows/templates/shows/index.html
+++ b/app/shows/templates/shows/index.html
@@ -18,22 +18,22 @@
         <ul class="list-group show-list">
             <li class="list-group-item">
                 <a href="{{ url_for('shows.best_ofs') }}">
-                    <i class="bi-star" aria-hidden="true"></i>Best Of Shows
+                    <i class="bi bi-star" aria-hidden="true"></i>Best Of Shows
                 </a>
             </li>
             <li class="list-group-item">
                 <a href="{{ url_for('shows.repeat_best_ofs') }}">
-                    <i class="bi-star" aria-hidden="true"></i><i class="bi-repeat" aria-hidden="true"></i>Repeat Best Of Shows
+                    <i class="bi bi-star" aria-hidden="true"></i><i class="bi bi-repeat" aria-hidden="true"></i>Repeat Best Of Shows
                 </a>
             </li>
             <li class="list-group-item">
                 <a href="{{ url_for('shows.repeats') }}">
-                    <i class="bi-repeat" aria-hidden="true"></i>Repeat Shows
+                    <i class="bi bi-repeat" aria-hidden="true"></i>Repeat Shows
                 </a>
             </li>
             <li class="list-group-item">
                 <a href="{{ url_for('shows.random') }}">
-                    <i class="bi-shuffle" aria-hidden="true"></i>Random Show
+                    <i class="bi bi-shuffle" aria-hidden="true"></i>Random Show
                 </a>
             </li>
             {% for year in show_years %}

--- a/app/shows/templates/shows/year.html
+++ b/app/shows/templates/shows/year.html
@@ -20,7 +20,7 @@
         <ul class="list-group show-list">
             <li class="list-group-item">
                 <a href="{{ url_for('shows.random_year_show', show_year=year.year) }}">
-                    <i class="bi-shuffle" aria-hidden="true"></i>Random Show from {{ year.year }}
+                    <i class="bi bi-shuffle" aria-hidden="true"></i>Random Show from {{ year.year }}
                 </a>
             </li>
             {% for month in show_months %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,6 +3,7 @@
 <head>
     <title>{% block title %}{% endblock %} | Wait Wait Don't Tell Me! Stats Page</title>
     {% include "core/head.html" with context %}
+    {% include "core/init_js.html" %}
 </head>
 <body class="d-flex flex-column h-100">
 {% include "core/nav.html" %}
@@ -14,8 +15,6 @@
 </main>
 
 {% include "core/footer.html" %}
-
-{% include "core/init_js.html" %}
 </body>
 
 </html>

--- a/app/templates/core/head.html
+++ b/app/templates/core/head.html
@@ -30,5 +30,5 @@
     {% endif %}
 
     {%- if umami %}
-        {% include "core/umami.html" %}
+    {% include "core/umami.html" %}
     {% endif %}

--- a/app/templates/core/init_js.html
+++ b/app/templates/core/init_js.html
@@ -1,3 +1,2 @@
-<!--JavaScript at end of body for optimized loading-->
-<script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>
-<script src="{{ url_for('static', filename='js/app-code.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/bootstrap.bundle.min.js') }}"></script>
+    <script src="{{ url_for('static', filename='js/app-code.js') }}"></script>

--- a/app/templates/core/nav.html
+++ b/app/templates/core/nav.html
@@ -9,7 +9,7 @@
                 data-bs-toggle="offcanvas" data-bs-target="#offcanvasNavbar"
                 aria-controls="offcanvasNavbar" aria-expanded="false"
                 aria-label="Toggle navigation">
-                <i class="bi-list"></i>
+                <i class="bi bi-list"></i>
             </button>
             <h1><a class="navbar-brand" href="{{ url_for('main.index') }}">Wait Wait Stats Page</a></h1>
 
@@ -48,27 +48,27 @@
                         <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('shows.best_ofs') }}" title="Best Of Shows" aria-hidden="false"
                                 aria-label="Best Of Shows">
-                                <i class="bi-star" aria-hidden="true"></i>
+                                <i class="bi bi-star" aria-hidden="true"></i>
                                 <span class="d-xl-none">Best Of Shows</span>
                             </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('shows.on_this_day') }}" title="On This Day" aria-hidden="false"
                                 aria-label="On This Day">
-                                <i class="bi-calendar-event" aria-hidden="true"></i>
+                                <i class="bi bi-calendar-event" aria-hidden="true"></i>
                                 <span class="d-xl-none">On This Day</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('shows.random') }}" title="Random Show"
                                 aria-hidden="false" aria-label="Random Show">
-                                <i class="bi-shuffle" aria-hidden="true"></i>
+                                <i class="bi bi-shuffle" aria-hidden="true"></i>
                                 <span class="d-xl-none">Random Show</span>
                             </a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('shows.repeats') }}" title="Repeat Shows" aria-hidden="false"
                                 aria-label="Repeat Shows">
-                                <i class="bi-repeat" aria-hidden="true"></i>
+                                <i class="bi bi-repeat" aria-hidden="true"></i>
                                 <span class="d-xl-none">Repeat Shows</span>
                             </a>
                         </li>
@@ -106,7 +106,7 @@
                             <button class="btn btn-link nav-link dropdown-toggle d-flex align-items-center"
                                 id="bd-theme" type="button" aria-expanded="false" data-bs-toggle="dropdown"
                                 data-bs-display="static" aria-label="Toggle Theme (Auto)">
-                                <i class="bi-circle-half"></i>
+                                <i class="bi bi-circle-half"></i>
                                 <span class="d-xl-none" id="bd-theme-text">Toggle theme</span>
                             </button>
                             <ul class="dropdown-menu dropdown-menu-end" id="theme-dropdown"
@@ -114,21 +114,21 @@
                                 <li>
                                     <button type="button" class="dropdown-item d-flex align-items-center"
                                         data-bs-theme-value="light" aria-pressed="false">
-                                        <i class="bi-sun-fill"></i>
+                                        <i class="bi bi-sun-fill"></i>
                                         Light
                                     </button>
                                 </li>
                                 <li>
                                     <button type="button" class="dropdown-item d-flex align-items-center"
                                         data-bs-theme-value="dark" aria-pressed="false">
-                                        <i class="bi-moon-stars-fill"></i>
+                                        <i class="bi bi-moon-stars-fill"></i>
                                         Dark
                                     </button>
                                 </li>
                                 <li>
                                     <button type="button" class="dropdown-item d-flex align-items-center active"
                                         data-bs-theme-value="auto" aria-pressed="true">
-                                        <i class="bi-circle-half"></i>
+                                        <i class="bi bi-circle-half"></i>
                                         Auto
                                     </button>
                                 </li>

--- a/app/templates/errors/base.html
+++ b/app/templates/errors/base.html
@@ -15,9 +15,8 @@
     </script>
     {% endif %}
 
-    {% if umami_analytics %}
-    <!-- Umami Analytics -->
-    {{ umami_analytics|safe }}
+    {%- if umami %}
+    {% include "core/umami.html" %}
     {% endif %}
 </head>
 <body>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.5.4"
+APP_VERSION = "6.5.5"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ pytest==8.3.3
 pytest-cov==5.0.0
 
 Flask==3.1.0
+Jinja2~=3.1.6
 gunicorn==23.0.0
 Markdown==3.7.0
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Flask==3.1.0
+Jinja2~=3.1.6
 gunicorn==23.0.0
 Markdown==3.7.0
 


### PR DESCRIPTION
## Application Changes

- Relocate the Bootstrap and application code initialization from towards the end of the document to the head to prevent background flashing on page loads when in dark mode
- Corrected Umami Analytics include for error page template
- Update Bootstrap icon classes to include `.bi`

## Component Changes

- Set Jinja2 version to `~=3.1.6`