### PR TITLE
Change shows.random route to return redirect URL for shows.year_month_day instead of shows.date_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changes
 
+## 6.6.3
+
+### Application Changes
+
+- Change the `/shows/random` route to redirect using `shows.year_month_day` rather than `shows.date_string`
+  - Example: Instead of the route returning `/shows/2018-10-27`, the route will return `/shows/2018/10/27`
+  - The route will use the `shows.date_string` route as a fallback option
+  - If no random date should be pulled from the database, redirect to the Shows index page
+
 ## 6.6.2
 
 ### Component Changes

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.6.2"
+APP_VERSION = "6.6.3"

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -142,6 +142,7 @@ def test_random(client: FlaskClient) -> None:
     response: TestResponse = client.get("/shows/random")
     assert response.status_code == 302
     assert response.location
+    assert "/shows/" in response.location
 
 
 @pytest.mark.parametrize("year", [1998, 2020])


### PR DESCRIPTION
## Application Changes

- Change the `/shows/random` route to redirect using `shows.year_month_day` rather than `shows.date_string`
  - Example: Instead of the route returning `/shows/2018-10-27`, the route will return `/shows/2018/10/27`
  - The route will use the `shows.date_string` route as a fallback option
  - If no random date should be pulled from the database, redirect to the Shows index page