### PR TITLE
Fix /show/random/<int:year> route and use the new random date object methods in wwdtm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changes
 
+## 6.6.4
+
+### Application Changes
+
+- Fixed a bug in the `/shows/random/<int:year>` route where the database connection close command was not moved to the correct location
+- Change `/shows/random` and `/shows/random/<int:year>` to use the new `wwdtm.show.Show.retrieve_random_date_object()` and `wwdtm.show.Show.retrieve_random_date_object_by_year()` methods
+
+### Component Changes
+
+- Upgrade wwdtm from 2.18.2 to 2.19.0
+
 ## 6.6.3
 
 ### Application Changes

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.6.3"
+APP_VERSION = "6.6.4"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,4 @@ Jinja2~=3.1.6
 gunicorn==23.0.0
 Markdown==3.7.0
 
-wwdtm==2.18.2
+wwdtm==2.19.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ Jinja2~=3.1.6
 gunicorn==23.0.0
 Markdown==3.7.0
 
-wwdtm==2.18.2
+wwdtm==2.19.0


### PR DESCRIPTION
## Application Changes

- Fixed a bug in the `/shows/random/<int:year>` route where the database connection close command was not moved to the correct location
- Change `/shows/random` and `/shows/random/<int:year>` to use the new `wwdtm.show.Show.retrieve_random_date_object()` and `wwdtm.show.Show.retrieve_random_date_object_by_year()` methods

## Component Changes

- Upgrade wwdtm from 2.18.2 to 2.19.0