### PR TITLE
Update Markdown to HTML filter for external links, update block_ai_scrapers logic

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,3 +1,5 @@
+[MESSAGE CONTROL]
+exclude = R0903
+
 [design]
 max-locals = 20
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changes
 
+## 6.6.5
+
+### Application Changes
+
+- Update the Markdown to HTML filter to modify generated external links to open in a new window/tab and add the `bi-box-arrow-up-right` icon at the end of the link text
+- Update list of AI scraper user agents
+- Change the `block_ai_scrapers` logic so that if the configuration key is set to `true`, the action is set to `Disallow: /`. If the configuration key is set to `false`, the action is set to `Crawl-delay: 10`
+
 ## 6.6.4
 
 ### Application Changes

--- a/app/templates/robots.txt
+++ b/app/templates/robots.txt
@@ -6,25 +6,35 @@ Sitemap: {{ site_url }}{{ url_for("sitemaps.panelists") }}
 Sitemap: {{ site_url }}{{ url_for("sitemaps.scorekeepers") }}
 Sitemap: {{ site_url }}{{ url_for("sitemaps.shows") }}
 
-{% if block_ai_scrapers %}
 User-agent: AI2Bot
 User-agent: Ai2Bot-Dolma
+User-agent: aiHitBot
 User-agent: Amazonbot
 User-agent: anthropic-ai
 User-agent: Applebot
 User-agent: Applebot-Extended
+User-agent: AwarioBot
+User-agent: AwarioRssBot
+User-agent: AwarioSmartBot
+User-agent: Brightbot 1.0
 User-agent: Bytespider
 User-agent: CCBot
 User-agent: ChatGPT-User
+User-agent: Claude-SearchBot
+User-agent: Claude-User
 User-agent: Claude-Web
 User-agent: ClaudeBot
 User-agent: cohere-ai
 User-agent: cohere-training-data-crawler
+User-agent: Cotoyogi
 User-agent: Crawlspace
 User-agent: Diffbot
 User-agent: DuckAssistBot
 User-agent: FacebookBot
+User-agent: Factset_spyderbot
+User-agent: FirecrawlAgent
 User-agent: FriendlyCrawler
+User-agent: Google-CloudVertexBot
 User-agent: Google-Extended
 User-agent: GoogleOther
 User-agent: GoogleOther-Image
@@ -34,25 +44,38 @@ User-agent: iaskspider/2.0
 User-agent: ICC-Crawler
 User-agent: ImagesiftBot
 User-agent: img2dataset
+User-agent: imgproxy
 User-agent: ISSCyberRiskCrawler
 User-agent: Kangaroo Bot
+User-agent: meta-externalagent
 User-agent: Meta-ExternalAgent
+User-agent: meta-externalfetcher
 User-agent: Meta-ExternalFetcher
+User-agent: MistralAI-User/1.0
+User-agent: NovaAct
 User-agent: OAI-SearchBot
 User-agent: omgili
 User-agent: omgilibot
+User-agent: Operator
 User-agent: PanguBot
+User-agent: Perplexity-User
 User-agent: PerplexityBot
 User-agent: PetalBot
+User-agent: QualifiedBot
 User-agent: Scrapy
 User-agent: SemrushBot-OCOB
 User-agent: SemrushBot-SWA
 User-agent: Sidetrade indexer bot
+User-agent: TikTokSpider
 User-agent: Timpibot
 User-agent: VelenPublicWebCrawler
 User-agent: Webzio-Extended
+User-agent: wpbot
 User-agent: YouBot
+{% if block_ai_scrapers %}
 Disallow: /
+{% else %}
+Crawl-delay: 10
 {% endif %}
 
 User-agent: *

--- a/app/utility.py
+++ b/app/utility.py
@@ -6,6 +6,7 @@
 """Utility functions used by the Wait Wait Stats Page."""
 
 import json
+import re
 from datetime import datetime
 
 import markdown
@@ -40,9 +41,17 @@ def generate_date_time_stamp(time_zone: str = "UTC") -> str:
     return now.strftime("%Y-%m-%d %H:%M:%S %Z")
 
 
-def md_to_html(text: str):
+def md_to_html(markdown_text: str):
     """Converts Markdown text into HTML."""
-    return markdown.markdown(text, output_format="html")
+    html_text = markdown.markdown(markdown_text, output_format="html")
+    site_url = current_app.jinja_env.globals["site_url"]
+
+    if html_text and site_url:
+        pattern = r'(<a\s+href="((?:(?!' + site_url + r').)*?)")>([^<]+)</a>'
+        replacement = r'\1 target="_blank">\3<i class="bi bi-box-arrow-up-right px-1" aria-hidden="true"></i></a>'
+        updated_html = re.sub(pattern, replacement, html_text, flags=re.DOTALL)
+
+    return updated_html
 
 
 def pretty_jsonify(data):

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.6.4"
+APP_VERSION = "6.6.5"


### PR DESCRIPTION
## Application Changes

- Update the Markdown to HTML filter to modify generated external links to open in a new window/tab and add the `bi-box-arrow-up-right` icon at the end of the link text
- Update list of AI scraper user agents
- Change the `block_ai_scrapers` logic so that if the configuration key is set to `true`, the action is set to `Disallow: /`. If the configuration key is set to `false`, the action is set to `Crawl-delay: 10`