### PR TITLE
Fix Not My Job Guest score exception handling and add Support NPR link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,12 @@
 # Changes
 
-## 6.7.2
-
-### Application Changes
-
-- Add `support_npr_url` to the `app_settings` section in the `config.json` file
-- Display link to "Support NPR" in the pop-out side navigation and in the footer with the value from `support_npr_url`, if not blank or `None`
-
 ## 6.7.1
 
 ### Application Changes
 
-- Updated handling of Not My Job Guest score exception in both Shows and Guests details pages so that the `<span>` for the score exception only appears when there is a score exception. Previously, an empty `<span>` was needlessly rendered for all guest score entries.
+- Updated handling of Not My Job Guest score exception in both Shows and Guests details pages so that the `<span>` for the score exception only appears when there is a score exception. Previously, an empty `<span>` was needlessly rendered for all guest score entries
+- - Add `support_npr_url` to the `app_settings` section in the `config.json` file
+- Display link to "Support NPR" in the pop-out side navigation and in the footer with the value from `support_npr_url`, if not blank or `None`
 
 ## 6.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 6.7.2
+
+### Application Changes
+
+- Add `support_npr_url` to the `app_settings` section in the `config.json` file
+- Display link to "Support NPR" in the pop-out side navigation and in the footer with the value from `support_npr_url`, if not blank or `None`
+
 ## 6.7.1
 
 ### Application Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 6.7.1
+
+### Application Changes
+
+- Updated handling of Not My Job Guest score exception in both Shows and Guests details pages so that the `<span>` for the score exception only appears when there is a score exception. Previously, an empty `<span>` was needlessly rendered for all guest score entries.
+
 ## 6.7.0
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -66,6 +66,9 @@ def create_app() -> Flask:
     app.jinja_env.globals["mastodon_user"] = _config["settings"].get(
         "mastodon_user", ""
     )
+    app.jinja_env.globals["support_npr_url"] = _config["settings"].get(
+        "support_npr_url", ""
+    )
     app.jinja_env.globals["patreon_url"] = _config["settings"].get("patreon_url", "")
     app.jinja_env.globals["github_sponsor_url"] = _config["settings"].get(
         "github_sponsor_url", ""

--- a/app/guests/templates/guests/details.html
+++ b/app/guests/templates/guests/details.html
@@ -47,15 +47,13 @@
                     {% set show_date = date_string_to_date(date_string=appearance.date) %}
                     <li>
                         <a href="{{ url_for('shows.year_month_day', show_year=show_date.year, show_month=show_date.month, show_day=show_date.day) }}">{{ appearance.date }}</a>
-                        {% if appearance.score != None and appearance.score_exception %}
+                        {% if appearance.score != None %}
                         <span class="score">
                             {{ appearance.score }}
-                            <span class="score-exception" data-bs-toggle="tooltip"
-                                title="Scoring Exception">{{ "*" if appearance.score_exception }}
-                            </span>
+                            {% if appearance.score_exception %}
+                            <span class="score-exception" data-bs-toggle="tooltip" title="Scoring Exception">*</span>
+                            {% endif %}
                         </span>
-                        {% elif appearance.score != None and not appearance.score_exception %}
-                        <span class="score">{{ appearance.score }}</span>
                         {% endif %}
                         {% if appearance.best_of %}
                         <span class="badge best-of">Best Of</span>

--- a/app/shows/templates/shows/all-details.html
+++ b/app/shows/templates/shows/all-details.html
@@ -128,8 +128,9 @@
                         {% if guest.score != None %}
                     <span class="score">
                         {{ guest.score }}
-                        <span class="score-exception" data-bs-toggle="tooltip"
-                            title="Scoring Exception">{{ "*" if guest.score_exception }}</span>
+                        {% if guest.score_exception %}
+                        <span class="score-exception" data-bs-toggle="tooltip" title="Scoring Exception">*</span>
+                        {% endif %}
                     </span>
                         {% endif %}
                     {% else %}

--- a/app/shows/templates/shows/details.html
+++ b/app/shows/templates/shows/details.html
@@ -132,8 +132,9 @@
                             {% if guest.score != None %}
                         <span class="score">
                             {{ guest.score }}
-                            <span class="score-exception" data-bs-toggle="tooltip"
-                                title="Scoring Exception">{{ "*" if guest.score_exception }}</span>
+                            {% if guest.score_exception %}
+                            <span class="score-exception" data-bs-toggle="tooltip" title="Scoring Exception">*</span>
+                            {% endif %}
                         </span>
                             {% endif %}
                         {% else %}

--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -1,6 +1,6 @@
 /*!
  * stats.wwdt.me (https://github.com/questionlp/stats.wwdt.me)
- * Copyright 2018-2024 Linh Pham
+ * Copyright 2018-2025 Linh Pham
  * Apache License 2.0 (https://github.com/questionlp/stats.wwdt.me/blob/main/LICENSE)
  */
 

--- a/app/static/js/app-code.js
+++ b/app/static/js/app-code.js
@@ -81,7 +81,7 @@
 
 /*!
  * stats.wwdt.me (https://github.com/questionlp/stats.wwdt.me)
- * Copyright 2018-2024 Linh Pham, Elijah Conners
+ * Copyright 2018-2025 Linh Pham, Elijah Conners
  * Apache License 2.0 (https://github.com/questionlp/stats.wwdt.me/blob/main/LICENSE)
  */
 

--- a/app/static/js/init.js
+++ b/app/static/js/init.js
@@ -1,6 +1,6 @@
 /*!
  * stats.wwdt.me (https://github.com/questionlp/stats.wwdt.me)
- * Copyright 2018-2024 Linh Pham
+ * Copyright 2018-2025 Linh Pham
  * Apache License 2.0 (https://github.com/questionlp/stats.wwdt.me/blob/main/LICENSE)
  */
 

--- a/app/static/js/location-map.js
+++ b/app/static/js/location-map.js
@@ -1,6 +1,6 @@
 /*!
  * stats.wwdt.me (https://github.com/questionlp/stats.wwdt.me)
- * Copyright 2018-2024 Linh Pham, Elijah Conners
+ * Copyright 2018-2025 Linh Pham, Elijah Conners
  * Apache License 2.0 (https://github.com/questionlp/stats.wwdt.me/blob/main/LICENSE)
  */
 

--- a/app/templates/core/footer.html
+++ b/app/templates/core/footer.html
@@ -17,6 +17,9 @@
                         {% if github_sponsor_url or patreon_url %}
                         <li><a href="{{ url_for('main.about') }}#support-stats">Support Wait Wait Stats</a></li>
                         {% endif %}
+                        {% if support_npr_url %}
+                        <li><a href="{{ support_npr_url }}" target="_blank">Support NPR</a></li>
+                        {% endif %}
                     </ul>
                 </div>
             </div>

--- a/app/templates/core/nav.html
+++ b/app/templates/core/nav.html
@@ -89,6 +89,14 @@
                         <li class="nav-item d-block d-xl-none">
                             <a class="nav-link" href="{{ blog_url }}" target="_blank">Blog</a>
                         </li>
+                        {% if support_npr_url %}
+                        <li class="nav-item d-block d-xl-none">
+                            <hr>
+                        </li>
+                        <li class="nav-item d-block d-xl-none">
+                            <a class="nav-link" href="{{ support_npr_url }}" target="_blank">Support NPR</a>
+                        </li>
+                        {% endif %}
                         {% if github_sponsor_url or patreon_url %}
                         <li class="nav-item d-block d-xl-none">
                             <hr>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.7.2"
+APP_VERSION = "6.7.1"

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.7.0"
+APP_VERSION = "6.7.1"

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.7.1"
+APP_VERSION = "6.7.2"

--- a/config.json.dist
+++ b/config.json.dist
@@ -43,6 +43,7 @@
         "mastodon_user": "",
         "patreon_url": "",
         "github_sponsor_url": "",
+        "support_npr_url": "",
         "sort_by_venue": false,
         "use_decimal_scores": false,
         "display_location_map": false,


### PR DESCRIPTION
### Application Changes

- Updated handling of Not My Job Guest score exception in both Shows and Guests details pages so that the `<span>` for the score exception only appears when there is a score exception. Previously, an empty `<span>` was needlessly rendered for all guest score entries
- - Add `support_npr_url` to the `app_settings` section in the `config.json` file
- Display link to "Support NPR" in the pop-out side navigation and in the footer with the value from `support_npr_url`, if not blank or `None`