### PR TITLE
Swap position of "Support NPR" link in footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 6.7.2
+
+### Application Changes
+
+- Swap position of the "Support NPR" link in the footer to match the ordering used on the [Wait Wait Reports Site](https://reports.wwdt.me/) and the upcoming version of the [Wait Wait Graphs Site](https://graphs.wwdt.me/)
+
 ## 6.7.1
 
 ### Application Changes

--- a/app/templates/core/footer.html
+++ b/app/templates/core/footer.html
@@ -14,11 +14,11 @@
                         <li><a href="{{ blog_url }}" target="_blank">Blog</a></li>
                         <li><a href="{{ graphs_url }}" target="_blank">Graphs</a></li>
                         <li><a href="{{ reports_url }}" target="_blank">Reports</a></li>
-                        {% if github_sponsor_url or patreon_url %}
-                        <li><a href="{{ url_for('main.about') }}#support-stats">Support Wait Wait Stats</a></li>
-                        {% endif %}
                         {% if support_npr_url %}
                         <li><a href="{{ support_npr_url }}" target="_blank">Support NPR</a></li>
+                        {% endif %}
+                        {% if github_sponsor_url or patreon_url %}
+                        <li><a href="{{ url_for('main.about') }}#support-stats">Support Wait Wait Stats</a></li>
                         {% endif %}
                     </ul>
                 </div>

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.7.1"
+APP_VERSION = "6.7.2"


### PR DESCRIPTION
## Application Changes

- Swap position of the "Support NPR" link in the footer to match the ordering used on the [Wait Wait Reports Site](https://reports.wwdt.me/) and the upcoming version of the [Wait Wait Graphs Site](https://graphs.wwdt.me/)