### PR TITLE
Added missing guest host badge on Host details page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 6.10.3
+
+### Application Changes
+
+- Added missing guest host badge for guest hosts in the Host details page
+
 ## 6.10.2
 
 ### Application Changes

--- a/app/hosts/templates/hosts/details.html
+++ b/app/hosts/templates/hosts/details.html
@@ -63,6 +63,9 @@
                     {% set show_date = date_string_to_date(date_string=appearance.date) %}
                     <li>
                         <a href="{{ url_for('shows.year_month_day', show_year=show_date.year, show_month=show_date.month, show_day=show_date.day) }}">{{ appearance.date }}</a>
+                        {% if appearance.guest %}
+                        <span class="badge guest">Guest</span>
+                        {% endif %}
                         {% if appearance.best_of %}
                         <span class="badge best-of">Best Of</span>
                         {% endif %}

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.10.2"
+APP_VERSION = "6.10.3"


### PR DESCRIPTION
## Application Changes

- Added missing guest host badge for guest hosts in the Host details page