### PR TITLE
Standardize on "Lightning Fill In The Blank" segment name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changes
 
+## 6.10.4
+
+### Application Changes
+
+- Standardized on the name and spelling "Lightning Fill In The Blank" instead of "Lightning Fill-in-the-Blank"
+
 ## 6.10.3
 
 ### Application Changes

--- a/app/templates/pages/understanding-data.html
+++ b/app/templates/pages/understanding-data.html
@@ -97,7 +97,7 @@
     <p>
         The scoring information for each panelist includes their total score,
         and if available, the score they had at the start of the final round
-        (currently known as "Lightning Fill-in-the-Blank") and how many
+        (currently known as "Lightning Fill In The Blank") and how many
         questions they answered correctly. The total score should equal the
         sum of starting score plus two times the number of correct answers.
         There can also be scoring anomalies that lead to a panelist not getting
@@ -367,7 +367,7 @@
     <p>
         If scoring information is available, the panelist's total score is
         listed along with their score at the start of the final round (currently
-        known as "Lightning Fill-in-the-Blank") and how many questions they
+        known as "Lightning Fill In The Blank") and how many questions they
         answered correctly. The total score should equal the sum of starting
         score plus two times the number of correct answers. There can also be
         scoring anomalies that lead to a panelist not getting credit for correct

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.10.3"
+APP_VERSION = "6.10.4"


### PR DESCRIPTION
## Application Changes

- Standardized on the name and spelling "Lightning Fill In The Blank" instead of "Lightning Fill-in-the-Blank"