### PR TITLE
Fix incorrect shows.routes.date_string error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changes
 
+## 6.10.5
+
+### Application Changes
+
+- Fixed exception handling logic for `shows.routes.date_string()` that was caused an additional unhandled exception
+
+### Development Changes
+
+- Added new test for `shows.routes.date_string()` with invalid date strings to validate that a redirect is being returned and not an error or a normal response
+
 ## 6.10.4
 
 ### Application Changes

--- a/app/shows/routes.py
+++ b/app/shows/routes.py
@@ -59,28 +59,30 @@ def date_string(iso_date_string: str) -> Response:
         parsed_date = datetime.datetime.strptime(iso_date_string, "%Y-%m-%d")
         database_connection = mysql.connector.connect(**current_app.config["database"])
         show_utility = ShowUtility(database_connection=database_connection)
-        if not show_utility.date_exists(
+
+        if show_utility.date_exists(
             year=parsed_date.year, month=parsed_date.month, day=parsed_date.day
         ):
+            database_connection.close()
+            return redirect_url(
+                url_for(
+                    "shows.year_month_day",
+                    show_year=parsed_date.year,
+                    show_month=parsed_date.month,
+                    show_day=parsed_date.day,
+                ),
+                301,
+            )
+        else:
+            database_connection.close()
             return redirect_url(url_for("shows.index"))
 
-        return redirect_url(
-            url_for(
-                "shows.year_month_day",
-                show_year=parsed_date.year,
-                show_month=parsed_date.month,
-                show_day=parsed_date.day,
-            ),
-            301,
-        )
     except ValueError:
         return redirect_url(url_for("shows.index"))
     except OverflowError:
         return redirect_url(url_for("shows.index"))
     except TypeError:
         return redirect_url(url_for("shows.index"))
-    finally:
-        database_connection.close()
 
 
 @blueprint.route("/<int:show_year>")

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.10.4"
+APP_VERSION = "6.10.5"

--- a/tests/test_shows.py
+++ b/tests/test_shows.py
@@ -26,6 +26,14 @@ def test_date_string(client: FlaskClient, date_string: str) -> None:
     assert response.location
 
 
+@pytest.mark.parametrize("date_string", ["abcd-ef-gh", "1-2", "3-2-1"])
+def test_date_string_invalid_value(client: FlaskClient, date_string: str) -> None:
+    """Testing shows.date_string with invalid date strings."""
+    response: TestResponse = client.get(f"/shows/{date_string}")
+    assert response.status_code in (301, 302)
+    assert response.location
+
+
 @pytest.mark.parametrize("year", [2018])
 def test_year(client: FlaskClient, year: int) -> None:
     """Testing shows.year."""


### PR DESCRIPTION
## Application Changes

- Fixed exception handling logic for `shows.routes.date_string()` that was caused an additional unhandled exception

## Development Changes

- Added new test for `shows.routes.date_string()` with invalid date strings to validate that a redirect is being returned and not an error or a normal response