### PR TITLE
Fix the correct Bluff the Listener label to be "Correct" and not "Chosen" on show and panelist details pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changes
 
+## 6.10.6
+
+### Application Changes
+
+- Fixed the issue on the show details page where the label for the panelist with the correct Bluff the Listener story was listed as "Chosen" and not "Correct"
+- Fixed the issue on the panelist details page where the label where the count of correct Bluff the Listener stories is not available was listed as "Chosen" and not "Correct"
+
 ## 6.10.5
 
 ### Application Changes

--- a/app/panelists/templates/panelists/details.html
+++ b/app/panelists/templates/panelists/details.html
@@ -115,7 +115,7 @@
                 {% if panelist.bluffs.correct %}
                     <li>Correct: {{ panelist.bluffs.correct }}</li>
                 {% else %}
-                    <li>Chosen: <span class="data-na">N/A</span></li>
+                    <li>Correct: <span class="data-na">N/A</span></li>
                 {% endif%}
                 </ul>
             </div>

--- a/app/shows/templates/shows/all-details.html
+++ b/app/shows/templates/shows/all-details.html
@@ -178,7 +178,7 @@
                 {% endif %}
                 </div>
                 <div class="col-md-5">
-                    <span class="field-label">Chosen</span>
+                    <span class="field-label">Correct</span>
                 {% if bluff.correct_panelist %}
                     <a href="{{ url_for('panelists.details', panelist_slug=bluff.correct_panelist.slug) }}">{{ bluff.correct_panelist.name }}</a>
                 {% else %}

--- a/app/shows/templates/shows/details.html
+++ b/app/shows/templates/shows/details.html
@@ -186,7 +186,7 @@
                     {% endif %}
                     </div>
                     <div class="col-md-5">
-                        <span class="field-label">Chosen</span>
+                        <span class="field-label">Correct</span>
                     {% if bluff.correct_panelist %}
                         <a href="{{ url_for('panelists.details', panelist_slug=bluff.correct_panelist.slug) }}">{{ bluff.correct_panelist.name }}</a>
                     {% else %}

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.10.5"
+APP_VERSION = "6.10.6"


### PR DESCRIPTION
## Application Changes

- Fixed the issue on the show details page where the label for the panelist with the correct Bluff the Listener story was listed as "Chosen" and not "Correct"
- Fixed the issue on the panelist details page where the label where the count of correct Bluff the Listener stories is not available was listed as "Chosen" and not "Correct"