### PR TITLE
Add configurable slug/date redirects, update location placeholders logic/config, update AI bot block handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,13 +4,17 @@ scss.bak/
 # Ignore CSS source maps
 # app/static/css/*.css.map
 
-# Ignore venv directory
+# Ignore venv directories
 venv/
+venv*/
+.venv/
+.venv*/
 
 # Ignore the default configuration files
 .env
 config.json
 gunicorn.conf.py
+url-redirects.json
 
 # Ignore uWSGI configuration and related files
 uwsgi.ini

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - Changed `parsed_date` from a `DateTime` object to `Date` in `shows.routes.date_string` rather than using `datetime.datetime.strptime` as the time portion of `DateTime` is not needed
 - Changed the behavior of the `block_ai_scrapers` settings flag to only include the list of blocked AI scrapers and the disallow statement in the rendered `robots.txt` file when set to `true`
 - Moved the `Crawl-delay: 10` line in the default `robots.txt` file to live under `User-agent: *`
+- Updated robots.txt to include latest list of AI bots from [ai-robots-txt/ai.robots.txt](https://github.com/ai-robots-txt/ai.robots.txt)
 
 ## 6.10.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changes
 
+## 6.11.0
+
+### Important Notes
+
+- Starting with version 6.12.0 of the Wait Wait Stats Page, Python 3.12 will become the minimum supported version of Python. The requirement is due to the [wwdtm](https://github.com/questionlp/wwdtm) library requiring Python 3.12 with support for newer versions being tested.
+
+### Application Changes
+
+- Added `location_placeholders` configuration setting in `config.json` to contain a list of location placeholder IDs, rather than hard-coding them within `locations.routes.details`. The default value if not defined in `config.json` will be `[3, 38]`
+- Added support for configurable URL redirects for guests, hosts, locations, panelists, scorekeepers and shows based on a new `url-redirects.json` file and logic added to specific routes. This removes the need of setting up specific redirects at the fronting web server or forwarding proxy level:
+  - The JSON file is read on application initialization. Default values for either `slugs` or `dates` objects are `None` if not defined in the JSON file.
+  - **Note:** A baseline `url-redirects.json.dist` file is included in the repository, but a copy of the file needs to be made and named `url-redirects.json` for the application to read in the values
+  - For guests, hosts, locations, panelsts and scorekeepers, a key/value pairs are defined within the respective `slugs` object, with the key being the slug string to match and the key value containing the slug string to use in the redirection
+  - For shows, a key/value pairs are defined within the `dates` object, with the key being an ISO-formatted date string
+  - For shows routes, both `date_string` and `year_month_day` have been updated to handle the new redirects
+  - Check for redirects done if the slug string or date doesn't match against an existing value in the database. This is prevent the need to check each and every request, which adds unwanted overhead
+- Added redirects for `/stats` and `/stats/` to return the URL for the main index route
+- Changed `parsed_date` from a `DateTime` object to `Date` in `shows.routes.date_string` rather than using `datetime.datetime.strptime` as the time portion of `DateTime` is not needed
+- Changed the behavior of the `block_ai_scrapers` settings flag to only include the list of blocked AI scrapers and the disallow statement in the rendered `robots.txt` file when set to `true`
+- Moved the `Crawl-delay: 10` line in the default `robots.txt` file to live under `User-agent: *`
+
 ## 6.10.6
 
 ### Application Changes

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -42,6 +42,13 @@ def create_app() -> Flask:
     _config = config.load_config()
     app.config["database"] = _config["database"]
     app.config["app_settings"] = _config["settings"]
+    app.config["location_placeholders"] = _config["settings"].get(
+        "location_placeholders", [3, 38]
+    )
+
+    # Load URL Redirects file
+    _redirects = config.load_url_redirects()
+    app.config["url_redirects"] = _redirects if _redirects else None
 
     # Set up Jinja globals
     app.jinja_env.globals["app_version"] = APP_VERSION

--- a/app/config.py
+++ b/app/config.py
@@ -5,6 +5,7 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Configuration Loading and Parsing for Wait Wait Stats Page."""
 
+import copy
 import json
 from datetime import date
 from pathlib import Path
@@ -14,6 +15,27 @@ from app import utility
 
 DEFAULT_RECENT_DAYS_AHEAD = 2
 DEFAULT_RECENT_DAYS_BACK = 30
+
+DEFAULT_URL_REDIRECTS: dict[str, dict[str, None]] = {
+    "guests": {
+        "slugs": None,
+    },
+    "hosts": {
+        "slugs": None,
+    },
+    "locations": {
+        "slugs": None,
+    },
+    "panelists": {
+        "slugs": None,
+    },
+    "scorekeepers": {
+        "slugs": None,
+    },
+    "shows": {
+        "dates": None,
+    },
+}
 
 
 def load_config(
@@ -120,3 +142,36 @@ def load_config(
         "database": database_config,
         "settings": settings_config,
     }
+
+
+def load_url_redirects(
+    url_redirects_path: str = "url-redirects.json",
+) -> dict[str, dict[str, str | None]]:
+    """Read URL Redirect Settings."""
+    _redirects = copy.deepcopy(DEFAULT_URL_REDIRECTS)
+    _url_redirects_path = Path(url_redirects_path)
+    if not _url_redirects_path.exists:
+        return DEFAULT_URL_REDIRECTS
+
+    with _url_redirects_path.open(mode="r", encoding="utf-8") as url_redirects_file:
+        url_redirects: dict[str, dict[str, str | None]] = json.load(url_redirects_file)
+
+    if "guests" in url_redirects:
+        _redirects["guests"]["slugs"] = url_redirects["guests"].get("slugs")
+
+    if "hosts" in url_redirects:
+        _redirects["hosts"]["slugs"] = url_redirects["hosts"].get("slugs")
+
+    if "locations" in url_redirects:
+        _redirects["locations"]["slugs"] = url_redirects["locations"].get("slugs")
+
+    if "panelists" in url_redirects:
+        _redirects["panelists"]["slugs"] = url_redirects["panelists"].get("slugs")
+
+    if "scorekeepers" in url_redirects:
+        _redirects["scorekeepers"]["slugs"] = url_redirects["scorekeepers"].get("slugs")
+
+    if "shows" in url_redirects:
+        _redirects["shows"]["dates"] = url_redirects["shows"].get("dates")
+
+    return _redirects

--- a/app/guests/routes.py
+++ b/app/guests/routes.py
@@ -38,6 +38,19 @@ def details(guest_slug: str) -> Response | str:
     _slug = slugify(guest_slug)
 
     if _slug not in slugs:
+        database_connection.close()
+        _guest_redirects: dict[str, str] = current_app.config["url_redirects"][
+            "guests"
+        ]["slugs"]
+        if _guest_redirects and _slug in _guest_redirects:
+            if _guest_redirects[_slug]:
+                return redirect(
+                    url_for("guests.details", guest_slug=_guest_redirects[_slug]),
+                    code=301,
+                )
+
+            return redirect(url_for("guests.index"))
+
         return redirect(url_for("guests.index"))
 
     if _slug in slugs and _slug != guest_slug:

--- a/app/hosts/routes.py
+++ b/app/hosts/routes.py
@@ -38,6 +38,18 @@ def details(host_slug: str) -> Response | str:
     _slug = slugify(host_slug)
 
     if _slug not in slugs:
+        database_connection.close()
+        _host_redirects: dict[str, str] = current_app.config["url_redirects"]["hosts"][
+            "slugs"
+        ]
+        if _host_redirects and _slug in _host_redirects:
+            if _host_redirects[_slug]:
+                return redirect(
+                    url_for("hosts.details", host_slug=_host_redirects[_slug]), code=301
+                )
+
+            return redirect_url(url_for("hosts.index"))
+
         return redirect(url_for("hosts.index"))
 
     if _slug in slugs and _slug != host_slug:

--- a/app/main/redirects.py
+++ b/app/main/redirects.py
@@ -130,3 +130,10 @@ def npr_show_redirect(show_date: str) -> Response:
 
     database_connection.close()
     return redirect_url(url_for("main.index"))
+
+
+@blueprint.route("/stats")
+@blueprint.route("/stats/")
+def stats() -> Response:
+    """Redirect: /stats and /stats/ to /."""
+    return redirect_url(url_for("main.index"), status_code=301)

--- a/app/panelists/routes.py
+++ b/app/panelists/routes.py
@@ -38,6 +38,21 @@ def details(panelist_slug: str) -> Response | str:
     _slug = slugify(panelist_slug)
 
     if _slug not in slugs:
+        database_connection.close()
+        _panelist_redirects: dict[str, str] = current_app.config["url_redirects"][
+            "panelists"
+        ]["slugs"]
+        if _panelist_redirects and _slug in _panelist_redirects:
+            if _panelist_redirects[_slug]:
+                return redirect(
+                    url_for(
+                        "panelists.details", panelist_slug=_panelist_redirects[_slug]
+                    ),
+                    code=301,
+                )
+
+            return redirect(url_for("panelists.index"))
+
         return redirect(url_for("panelists.index"))
 
     if _slug in slugs and _slug != panelist_slug:

--- a/app/scorekeepers/routes.py
+++ b/app/scorekeepers/routes.py
@@ -38,6 +38,22 @@ def details(scorekeeper_slug: str) -> Response | str:
     _slug = slugify(scorekeeper_slug)
 
     if _slug not in slugs:
+        database_connection.close()
+        _scorekeeper_redirects: dict[str, str] = current_app.config["url_redirects"][
+            "scorekeepers"
+        ]["slugs"]
+        if _scorekeeper_redirects and _slug in _scorekeeper_redirects:
+            if _scorekeeper_redirects[_slug]:
+                return redirect(
+                    url_for(
+                        "scorekeepers.details",
+                        scorekeeper_slug=_scorekeeper_redirects[_slug],
+                    ),
+                    code=301,
+                )
+
+            return redirect_url(url_for("scorekeepers.index"))
+
         return redirect_url(url_for("scorekeepers.index"))
 
     if _slug in slugs and _slug != scorekeeper_slug:

--- a/app/templates/robots.txt
+++ b/app/templates/robots.txt
@@ -6,6 +6,7 @@ Sitemap: {{ site_url }}{{ url_for("sitemaps.panelists") }}
 Sitemap: {{ site_url }}{{ url_for("sitemaps.scorekeepers") }}
 Sitemap: {{ site_url }}{{ url_for("sitemaps.shows") }}
 
+{% if block_ai_scrapers %}
 User-agent: AddSearchBot
 User-agent: AI2Bot
 User-agent: Ai2Bot-Dolma
@@ -101,13 +102,11 @@ User-agent: YaK
 User-agent: YandexAdditional
 User-agent: YandexAdditionalBot
 User-agent: YouBot
-{% if block_ai_scrapers %}
 Disallow: /
 {% else %}
-Crawl-delay: 10
-{% endif %}
 
 User-agent: *
+Crawl-delay: 10
 Disallow: {{ url_for("guests._all") }}$
 Disallow: {{ url_for("hosts._all") }}$
 Disallow: {{ url_for("panelists._all") }}$

--- a/app/templates/robots.txt
+++ b/app/templates/robots.txt
@@ -64,6 +64,7 @@ User-agent: meta-externalagent
 User-agent: Meta-ExternalAgent
 User-agent: meta-externalfetcher
 User-agent: Meta-ExternalFetcher
+User-agent: meta-webindexer
 User-agent: MistralAI-User
 User-agent: MistralAI-User/1.0
 User-agent: MyCentralAIScraperBot
@@ -91,6 +92,7 @@ User-agent: SemrushBot-OCOB
 User-agent: SemrushBot-SWA
 User-agent: ShapBot
 User-agent: Sidetrade indexer bot
+User-agent: TerraCotta
 User-agent: Thinkbot
 User-agent: TikTokSpider
 User-agent: Timpibot

--- a/app/templates/robots.txt
+++ b/app/templates/robots.txt
@@ -103,7 +103,7 @@ User-agent: YandexAdditional
 User-agent: YandexAdditionalBot
 User-agent: YouBot
 Disallow: /
-{% else %}
+{% endif %}
 
 User-agent: *
 Crawl-delay: 10

--- a/app/version.py
+++ b/app/version.py
@@ -5,4 +5,4 @@
 # vim: set noai syntax=python ts=4 sw=4:
 """Application Version for Wait Wait Stats Page."""
 
-APP_VERSION = "6.10.6"
+APP_VERSION = "6.11.0"

--- a/config.json.dist
+++ b/config.json.dist
@@ -10,7 +10,6 @@
         "charset": "utf8mb4",
         "collation": "utf8mb4_unicode_ci"
     },
-
     "settings": {
         "api_url": "",
         "blog_url": "",
@@ -49,5 +48,9 @@
         "display_location_map": false,
         "block_ai_scrapers": false,
         "use_minified_css": true,
+        "location_placeholders": [
+            3,
+            38
+        ]
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ ignore = [
     "F401",
     "TRY003", # Avoid specifying messages outside exception class; overly strict, especially for ValueError
     "S608",
+    "SIM102",
 ]
 
 select = [

--- a/tests/test_main_redirects.py
+++ b/tests/test_main_redirects.py
@@ -127,3 +127,14 @@ def test_npr_show_redirect(client: FlaskClient, show_date: str) -> None:
     response: TestResponse = client.get(f"/s/{show_date}")
     assert response.status_code == 302
     assert response.location
+
+
+def test_stats(client: FlaskClient) -> None:
+    """Testing main_redirects.stats."""
+    response: TestResponse = client.get("/stats")
+    assert response.status_code == 301
+    assert response.location
+
+    response: TestResponse = client.get("/stats/")
+    assert response.status_code == 301
+    assert response.location

--- a/url-redirects.json.dist
+++ b/url-redirects.json.dist
@@ -21,8 +21,7 @@
     "scorekeepers": {
         "slugs": {
             "che-kweku": "che-rhymefest-smith",
-            "robert-siegel": "robert-siegel-npr",
-            "test": null
+            "robert-siegel": "robert-siegel-npr"
         }
     },
     "shows": {

--- a/url-redirects.json.dist
+++ b/url-redirects.json.dist
@@ -1,0 +1,33 @@
+{
+    "guests": {
+        "slugs": {
+            "anna-kendrick-1149": "anna-kendrick",
+            "nina-totenberg-and-robert-siegel": "nina-totenberg-and-robert-siegel-npr"
+        }
+    },
+    "hosts": {
+        "slugs": {
+            "robert-siegel": "robert-siegel-npr"
+        }
+    },
+    "locations": {
+        "slugs": {
+            "wang-theatre-at-citi-performing-arts-center-boston-ma": "wang-theatre-boston-ma"
+        }
+    },
+    "panelists": {
+        "slugs": null
+    },
+    "scorekeepers": {
+        "slugs": {
+            "che-kweku": "che-rhymefest-smith",
+            "robert-siegel": "robert-siegel-npr",
+            "test": null
+        }
+    },
+    "shows": {
+        "dates": {
+            "2025-02-13": "2025-02-15"
+        }
+    }
+}


### PR DESCRIPTION
## Application Changes

- Added `location_placeholders` configuration setting in `config.json` to contain a list of location placeholder IDs, rather than hard-coding them within `locations.routes.details`. The default value if not defined in `config.json` will be `[3, 38]`
- Added support for configurable URL redirects for guests, hosts, locations, panelists, scorekeepers and shows based on a new `url-redirects.json` file and logic added to specific routes. This removes the need of setting up specific redirects at the fronting web server or forwarding proxy level:
  - The JSON file is read on application initialization. Default values for either `slugs` or `dates` objects are `None` if not defined in the JSON file.
  - **Note:** A baseline `url-redirects.json.dist` file is included in the repository, but a copy of the file needs to be made and named `url-redirects.json` for the application to read in the values
  - For guests, hosts, locations, panelsts and scorekeepers, a key/value pairs are defined within the respective `slugs` object, with the key being the slug string to match and the key value containing the slug string to use in the redirection
  - For shows, a key/value pairs are defined within the `dates` object, with the key being an ISO-formatted date string
  - For shows routes, both `date_string` and `year_month_day` have been updated to handle the new redirects
  - Check for redirects done if the slug string or date doesn't match against an existing value in the database. This is prevent the need to check each and every request, which adds unwanted overhead
- Added redirects for `/stats` and `/stats/` to return the URL for the main index route
- Changed `parsed_date` from a `DateTime` object to `Date` in `shows.routes.date_string` rather than using `datetime.datetime.strptime` as the time portion of `DateTime` is not needed
- Changed the behavior of the `block_ai_scrapers` settings flag to only include the list of blocked AI scrapers and the disallow statement in the rendered `robots.txt` file when set to `true`
- Moved the `Crawl-delay: 10` line in the default `robots.txt` file to live under `User-agent: *`
- Updated robots.txt to include latest list of AI bots from [ai-robots-txt/ai.robots.txt](https://github.com/ai-robots-txt/ai.robots.txt)